### PR TITLE
improve performance on doctrine stats page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ doctrine_status_performance.md
 helpers.py
 debug-tests.py
 experiments.py
+dev.py

--- a/db_handler.py
+++ b/db_handler.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 import streamlit as st
 
 import requests
@@ -71,6 +71,11 @@ def read_df(
                 logger.error("Failed to sync local DB; falling back to remote read.")
                 return _run_remote()
         raise
+
+def new_read_df(db: DatabaseConfig, query: Any, params: Mapping[str, Any] | None = None) -> pd.DataFrame:
+    """Execute a read-only SQL query and return a DataFrame."""
+    with db.ro_engine.connect() as conn:
+        return pd.read_sql_query(query, conn, params=params)
 
 @st.cache_data(ttl=600)
 def get_all_mkt_stats()->pd.DataFrame:

--- a/doctrines.py
+++ b/doctrines.py
@@ -1,10 +1,14 @@
 import sys
 import os
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import streamlit as st
 import pandas as pd
 from config import DatabaseConfig
 from logging_config import setup_logging
+import time
+from sqlalchemy import text
+from db_handler import read_df, new_read_df
 
 # Insert centralized logging configuration
 logger = setup_logging(__name__)
@@ -49,92 +53,103 @@ def get_target_value(ship_name):
     # Look up in the targets dictionary, default to 20 if not found
     return SHIP_TARGETS.get(ship_name, SHIP_TARGETS['default'])
 
+def get_target_values_batch(ship_names):
+    """Get target values for multiple ship types efficiently"""
+    if USE_DB_TARGETS:
+        # If using DB, still call individual functions for now
+        # TODO: Implement batch DB lookup if needed
+        return [get_target_value(name) for name in ship_names]
+
+    # For dictionary lookup, use vectorized pandas operations
+    ship_names_title = pd.Series(ship_names).str.title().fillna('')
+    return ship_names_title.map(SHIP_TARGETS).fillna(SHIP_TARGETS['default']).tolist()
+
+def new_get_targets():
+    df = new_read_df(mktdb, text("SELECT * FROM ship_targets"))
+    return df
+
 @st.cache_data(ttl=600, show_spinner="Loading cached doctrine fits...")
 def create_fit_df()->pd.DataFrame:
     logger.info("Creating fit dataframe")
+    t0 = time.perf_counter()
     df = get_all_fit_data()
+    t1 = time.perf_counter()
+    elapsed_time = round((t1 - t0)*1000, 2)
+    logger.info(f"TIME get_all_fit_data() = {elapsed_time} ms")
 
     if df.empty:
-        return pd.DataFrame()
+        return pd.DataFrame(), pd.DataFrame()
 
-    fit_ids = df['fit_id'].unique().tolist()
-    master_df = pd.DataFrame()
+    # Use vectorized operations instead of iterating through each fit
+    logger.info("Processing fit data with vectorized operations")
 
-    #note: only used if you want the fit summary as its own dataframe
-    fits = []
+    # Group by fit_id and aggregate data efficiently
+    fit_summary = df.groupby('fit_id').agg({
+        'ship_name': 'first',
+        'ship_id': 'first',
+        'hulls': 'first',
+        'fits_on_mkt': 'min',
+        'avg_vol': 'first' if 'avg_vol' in df.columns else lambda x: 0
+    }).reset_index()
 
-    # Process each fit
-    for fit_id in fit_ids:
-        # Filter data for this fit
-        df2 = df[df['fit_id'] == fit_id]
+    # Get ship group and price data efficiently
+    ship_data = df[df['type_id'] == df['ship_id']].groupby('fit_id').agg({
+        'group_name': 'first',
+        'price': 'first'
+    }).reset_index()
 
-        if df2.empty:
-            continue
-        # Create a dataframe for this fit
-        fit_df = pd.DataFrame()
-        fit_df["fit_id"] = [df2['fit_id'].iloc[0]]
-        fit_df["ship_name"] = [df2['ship_name'].iloc[0]]
-        fit_df["ship_id"] = [df2['ship_id'].iloc[0]]
-        fit_df["hulls"] = [df2['hulls'].iloc[0]]
-        fit_df["fits"] = [df2["fits_on_mkt"].min()]
+    # Merge the data
+    fit_summary = fit_summary.merge(ship_data, on='fit_id', how='left')
+    fit_summary['price'] = fit_summary['price'].fillna(0)
+    fit_summary['ship_group'] = fit_summary['group_name']
 
-        #get the ship group
-        ship_row = df2[df2.type_id == df2['ship_id'].iloc[0]]
-        group_name = ship_row['group_name'].iloc[0]
-        fit_df["ship_group"] = [group_name]
-        # Get ship price
-        try:
-            df3 = df2[df2.type_id == df2['ship_id'].iloc[0]]
-            fit_df["price"] = [df3['price'].iloc[0] if not df3.empty else 0]
-        except (IndexError, KeyError):
-            fit_df["price"] = [0]
+    # Rename columns to match expected output
+    fit_summary = fit_summary.rename(columns={'fits_on_mkt': 'fits'})
 
-        # Get target value based on ship name
-        target_value = get_target_value(df2['ship_name'].iloc[0])
-        fit_df["ship_target"] = [target_value]
+    # Get target values for all ships at once (batch operation)
+    t2 = time.perf_counter()
+    targets_df = new_get_targets()
+    targets_df = targets_df.drop_duplicates(subset=['fit_id'], keep='first')
+    targets_df = targets_df.reset_index(drop=True)
+    targets_df = targets_df[['fit_id', 'ship_target']]
+    fit_summary = fit_summary.merge(targets_df, on='fit_id', how='left')
 
-        # Calculate target percentage - using scalar values to avoid Series comparison
-        fits_value = df2["fits_on_mkt"].min()
-        if target_value > 0:
-            target_percentage = min(100, int((fits_value / target_value) * 100))
-        else:
-            target_percentage = 0
+    t3 = time.perf_counter()
+    elapsed_time = round((t3 - t2)*1000, 2)
+    logger.info(f"TIME new_get_targets() = {elapsed_time} ms")
 
-        fit_df["target_percentage"] = [target_percentage]
+    # Calculate target percentages vectorized
+    fit_summary['target_percentage'] = (
+        (fit_summary['fits'] / fit_summary['ship_target'] * 100)
+        .clip(upper=100)
+        .fillna(0)
+        .astype(int)
+    )
 
-        # Get daily average volume if available
-        avg_vol = ship_row['avg_vol'].iloc[0] if 'avg_vol' in ship_row.columns else 0
-        fit_df["daily_avg"] = avg_vol
+    # Handle division by zero case
+    fit_summary.loc[fit_summary['ship_target'] == 0, 'target_percentage'] = 0
 
-        # Add to master dataframe
-        master_df = pd.concat([master_df, df2])
+    # Set daily_avg column
+    if 'avg_vol' not in fit_summary.columns:
+        fit_summary['daily_avg'] = 0
+    else:
+        fit_summary['daily_avg'] = fit_summary['avg_vol'].fillna(0)
 
-        # uncomment this to get the fit summary as its own dataframe
-        fits.append(fit_df)
+    # Select final columns in the expected order
+    summary_columns = ['fit_id', 'ship_name', 'ship_id', 'hulls', 'fits',
+                      'ship_group', 'price', 'ship_target', 'target_percentage', 'daily_avg']
+    fit_summary = fit_summary[summary_columns]
 
-    summary_df = get_fit_summary(fits)
-    return master_df, summary_df
-
-def get_fit_summary(fits:list = None)->pd.DataFrame:
-    """Get a summary of all doctrine fits"""
-    # Add all the fit summary rows if needed (for a summary view)
-    fit_summary_df = pd.DataFrame()
-    if fits:
-        fit_summary_df = pd.concat(fits)
-        fit_summary_df.to_csv("fit_summary_df.csv", index=False)
-
-    return fit_summary_df
+    return df, fit_summary
 
 @st.cache_data(ttl=600)
 def get_all_fit_data()->pd.DataFrame:
     """Create a dataframe with all fit information"""
     logger.info("Getting fit info from doctrines table")
-    engine = mktdb.engine
+    engine = mktdb.ro_engine
     with engine.connect() as conn:
         df = pd.read_sql_query("SELECT * FROM doctrines", conn)
     return df
-
-
 
 if __name__ == "__main__":
     pass

--- a/models.py
+++ b/models.py
@@ -105,8 +105,7 @@ class Doctrines(Base):
 
 class ShipTargets(Base):
     __tablename__ = "ship_targets"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    fit_id: Mapped[int] = mapped_column(Integer)
+    fit_id: Mapped[int] = mapped_column(Integer, primary_key=True)
     fit_name: Mapped[str] = mapped_column(String)
     ship_id: Mapped[int] = mapped_column(Integer)
     ship_name: Mapped[str] = mapped_column(String)

--- a/set_targets.py
+++ b/set_targets.py
@@ -193,4 +193,4 @@ def load_new_ship_targets(new_targets: pd.DataFrame):
     logger.info("Ship targets loaded")
 
 if __name__ == "__main__":
-    update_from_targets_csv("dev_files/target_updates.csv")
+    pass


### PR DESCRIPTION
This PR resolves a longstanding performance issue on the doctrine stats page by refactoring inefficient code. Previously, the system retrieved fit targets for each ship via individual database calls inside a loop. To make matters worse, these queries hit the cloud database rather than our local embedded replica.

The revised approach vectorizes the logic: it retrieves all relevant data in a single query from the local database, then filters as needed—resulting in a significant performance boost.

This change eliminates an unnecessary bottleneck by eliminating a performance footgun I allowed to persist for too long.