### PR TITLE
dev: add local-only db mode for development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,9 +258,10 @@ api_key = "your_janice_api_key"  # For Pricer page Jita price lookups
 ### Local-Only Mode (for contributors without Turso access)
 Contributors can run the app without Turso cloud credentials:
 1. Download database files from: https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq
-2. Place `.db` files in the project root
+2. Place `.db` files (`wcmktprod.db`, `wcmktnorth2.db`, `sdelite.db`, `buildcost.db`) in the project root
 3. Set `local_only = true` in `settings.toml` under `[env]`
 4. No `.streamlit/secrets.toml` is needed — all sync operations are skipped
+5. The sidebar shows "Local-only mode — sync disabled" instead of update timestamps
 
 ## Development Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,8 @@ All pages follow consistent patterns with Streamlit best practices:
 ### Configuration Files
 
 - **`config.toml`**: Streamlit theme and UI configuration
-- **`settings.toml`**: Application settings including ship role definitions, special cases, `[db_paths]` alias-to-file mappings, and `[db_turso_keys]` alias-to-secret overrides
-- **`.streamlit/secrets.toml`**: Turso credentials (local only, git-ignored)
+- **`settings.toml`**: Application settings including ship role definitions, special cases, `[db_paths]` alias-to-file mappings, `[db_turso_keys]` alias-to-secret overrides, and `[env] local_only` toggle for running without Turso
+- **`.streamlit/secrets.toml`**: Turso credentials (local only, git-ignored; not needed when `local_only = true`)
 - **`pyproject.toml`**: Project metadata, dependencies, dev tools config
 
 ### Other Directories
@@ -254,6 +254,13 @@ api_key = "your_janice_api_key"  # For Pricer page Jita price lookups
 - The application will use local SQLite files if sync credentials are not available
 - Database files are git-ignored (*.db, *.db-shm, *.db-wal)
 - Logs are stored in `logs/` directory (git-ignored)
+
+### Local-Only Mode (for contributors without Turso access)
+Contributors can run the app without Turso cloud credentials:
+1. Download database files from: https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq
+2. Place `.db` files in the project root
+3. Set `local_only = true` in `settings.toml` under `[env]`
+4. No `.streamlit/secrets.toml` is needed — all sync operations are skipped
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,24 @@ token = "your_buildcost_auth_token"
 uv run streamlit run app.py
 ```
 
+### Local Development (without Turso access)
+
+Contributors who don't have Turso cloud credentials can run the app using pre-built database snapshots:
+
+1. Download the database files from the shared [Google Drive folder](https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq)
+2. Place the `.db` files (`wcmktprod.db`, `sdelite.db`, `buildcost.db`) in the project root directory
+3. Enable local-only mode in `settings.toml`:
+```toml
+[env]
+    local_only = true
+```
+4. Run the app normally — no `.streamlit/secrets.toml` needed:
+```bash
+uv run streamlit run app.py
+```
+
+In local-only mode, all Turso sync operations are skipped and the app reads directly from the local database files. The sidebar sync button will display "Local-only mode" instead of attempting remote checks.
+
 ### Local Secrets
 
 For local Streamlit runs, store credentials in `.streamlit/secrets.toml` (git‑ignored). This is the default source for database URLs/tokens used by `DatabaseConfig`. Example structure:

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ uv run streamlit run app.py
 Contributors who don't have Turso cloud credentials can run the app using pre-built database snapshots:
 
 1. Download the database files from the shared [Google Drive folder](https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq)
-2. Place the `.db` files (`wcmktprod.db`, `sdelite.db`, `buildcost.db`) in the project root directory
+2. Place the `.db` files (`wcmktprod.db`, `wcmktnorth2.db`, `sdelite.db`, `buildcost.db`) in the project root directory
 3. Enable local-only mode in `settings.toml`:
 ```toml
 [env]
@@ -295,7 +295,7 @@ Contributors who don't have Turso cloud credentials can run the app using pre-bu
 uv run streamlit run app.py
 ```
 
-In local-only mode, all Turso sync operations are skipped and the app reads directly from the local database files. The sidebar sync button will display "Local-only mode" instead of attempting remote checks.
+In local-only mode, all Turso sync operations are skipped and the app reads directly from the local database files. The sidebar shows "Local-only mode — sync disabled" in place of the update timestamps. If the sync button is clicked, a toast confirms that remote checks are skipped.
 
 ### Local Secrets
 

--- a/config.py
+++ b/config.py
@@ -57,8 +57,8 @@ class DatabaseConfig:
         try:
             _db_turso_urls[_turso_key] = st.secrets[_secret_key].url
             _db_turso_auth_tokens[_turso_key] = st.secrets[_secret_key].token
-        except (KeyError, AttributeError):
-            pass  # Not all aliases need Turso (graceful degradation)
+        except Exception:
+            pass  # Not all aliases need Turso; local-only mode has no secrets file
 
     # Shared handles per-alias to avoid multiple simultaneous connections to the same file
     _engines: dict[str, object] = {}
@@ -300,7 +300,15 @@ class DatabaseConfig:
         from settings_service import is_local_only
         if is_local_only():
             logger.info(f"sync() skipped for {self.alias} — local-only mode enabled")
-            return os.path.exists(self.path)
+            from init_db import verify_db_content
+            if verify_db_content(self.path):
+                return True
+            logger.warning(
+                f"sync() for {self.alias}: local file missing or empty at {self.path}. "
+                "Download from: https://drive.google.com/drive/folders/"
+                "1Hwx28Imyvc10jXcdKtLftZNi994AKKsq"
+            )
+            return False
 
         # Fail fast before libsql.connect() can create an empty db file
         if not self.turso_url or not self.token:

--- a/config.py
+++ b/config.py
@@ -296,6 +296,12 @@ class DatabaseConfig:
         Raises:
             ValueError: If Turso credentials are missing for this alias.
         """
+        # In local-only mode, skip all remote sync operations
+        from settings_service import is_local_only
+        if is_local_only():
+            logger.info(f"sync() skipped for {self.alias} — local-only mode enabled")
+            return os.path.exists(self.path)
+
         # Fail fast before libsql.connect() can create an empty db file
         if not self.turso_url or not self.token:
             raise ValueError(

--- a/init_db.py
+++ b/init_db.py
@@ -3,7 +3,7 @@ import os
 import sqlite3 as sql
 from logging_config import setup_logging
 from time import perf_counter
-from settings_service import get_all_market_configs
+from settings_service import get_all_market_configs, is_local_only
 
 logger = setup_logging(__name__)
 
@@ -92,6 +92,10 @@ def init_db():
     db_paths[sde_db.alias] = sde_db.path
     db_paths[build_cost_db.alias] = build_cost_db.path
 
+    local_only = is_local_only()
+    if local_only:
+        logger.info("Running in LOCAL-ONLY mode — Turso sync disabled")
+
     status = {}
 
     for key, value in db_paths.items():
@@ -103,6 +107,12 @@ def init_db():
             if verify_db_content(db_path):
                 logger.info(f"DB exists and has content: {db_path}✔️")
                 status[key] = "success initialized🟢"
+            elif local_only:
+                logger.warning(
+                    f"DB missing or empty: {db_path}. "
+                    "Download from: https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq"
+                )
+                status[key] = "missing (local-only mode)🔴"
             else:
                 # File is missing, empty, or has no tables — need to sync
                 if verify_db_path(db_path):
@@ -159,6 +169,14 @@ def ensure_market_db_ready(db_alias: str) -> bool:
 
     if verify_db_content(db.path):
         return True
+
+    if is_local_only():
+        logger.warning(
+            f"Market database '{db_alias}' ({db.path}) not found. "
+            "Running in local-only mode — download databases from: "
+            "https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq"
+        )
+        return False
 
     # Database is missing or empty — attempt sync
     logger.warning(f"Market database '{db_alias}' ({db.path}) not ready, attempting sync")

--- a/pages/components/db_refresh.py
+++ b/pages/components/db_refresh.py
@@ -40,7 +40,16 @@ def initialize_databases() -> bool:
         if result:
             st.session_state.db_initialized = True
         else:
-            st.toast("One or more databases failed to initialize", icon="❌")
+            from settings_service import is_local_only
+            if is_local_only():
+                st.error(
+                    "**Missing database files.** Download them from the "
+                    "[Google Drive folder](https://drive.google.com/drive/folders/"
+                    "1Hwx28Imyvc10jXcdKtLftZNi994AKKsq) "
+                    "and place the `.db` files in the project root."
+                )
+            else:
+                st.toast("One or more databases failed to initialize", icon="❌")
     else:
         logger.info("Databases already initialized in session state")
 
@@ -59,8 +68,9 @@ def check_for_db_updates(db_alias: str) -> tuple[bool, datetime]:
     The db_alias must be an explicit alias (e.g. "wcmktprod", "wcmktnorth")
     so the cache key correctly distinguishes between markets.
     """
+    from settings_service import is_local_only
     db = DatabaseConfig(db_alias)
-    if not db.has_remote_credentials:
+    if is_local_only() or not db.has_remote_credentials:
         logger.info(f"check_for_db_updates(): skipping remote validation for {db_alias}")
         local_time = datetime.now()
         return True, local_time
@@ -87,12 +97,13 @@ def check_db(manual_override: bool = False):
         logger.info("check_for_db_updates() cache cleared for manual override")
         logger.info("*" * 60)
 
+    from settings_service import is_local_only
     synced_any = False
     any_stale = False
-    local_only_mode = False
+    local_only_mode = is_local_only()
     for alias in all_aliases:
         db = DatabaseConfig(alias)
-        if not db.has_remote_credentials:
+        if local_only_mode or not db.has_remote_credentials:
             logger.info(f"check_db(): skipping {alias}; no remote credentials configured")
             local_only_mode = True
             continue

--- a/repositories/base.py
+++ b/repositories/base.py
@@ -102,6 +102,12 @@ class BaseRepository:
                     self.db.sync()
                     return _run_local()
                 except Exception:
+                    if not self.db.has_remote_credentials:
+                        self._logger.error(
+                            f"Local DB corrupt for '{self.db.alias}' and no remote "
+                            "credentials available. Re-download the database file."
+                        )
+                        raise
                     self._logger.error(
                         "Failed to sync local DB; falling back to remote read."
                     )

--- a/settings.toml
+++ b/settings.toml
@@ -104,6 +104,10 @@
 [env]
     env = "prod"
     log_level = "DEBUG" #INFO or DEBUG (case sensitive)
+    # Set to true for local development without Turso cloud access.
+    # Download databases from: https://drive.google.com/drive/folders/1Hwx28Imyvc10jXcdKtLftZNi994AKKsq
+    # Place .db files in the project root directory.
+    local_only = false
 
 [market]
     name = "4-HWWF"

--- a/settings_service.py
+++ b/settings_service.py
@@ -86,6 +86,16 @@ class SettingsService:
     def default_language(self) -> str:
         return self.settings.get("i18n", {}).get("default_language", "en")
 
+    @property
+    def local_only(self) -> bool:
+        """True when running without Turso cloud access (local .db files only)."""
+        return self.settings.get("env", {}).get("local_only", False)
+
+
+def is_local_only() -> bool:
+    """Return True when running in local-only mode (no Turso sync)."""
+    return _load_settings().get("env", {}).get("local_only", False)
+
 
 def resolve_db_alias(db_alias: str | None = None, fallback: str = "wcmkt") -> str:
     """Resolve a database alias, falling back to the active market hub.

--- a/settings_service.py
+++ b/settings_service.py
@@ -94,7 +94,7 @@ class SettingsService:
 
 def is_local_only() -> bool:
     """Return True when running in local-only mode (no Turso sync)."""
-    return _load_settings().get("env", {}).get("local_only", False)
+    return SettingsService().local_only
 
 
 def resolve_db_alias(db_alias: str | None = None, fallback: str = "wcmkt") -> str:

--- a/tests/test_local_only_mode.py
+++ b/tests/test_local_only_mode.py
@@ -1,0 +1,130 @@
+"""Tests for local-only mode feature.
+
+Validates that the is_local_only() gate works correctly and that
+sync() respects local-only mode.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestIsLocalOnly(unittest.TestCase):
+    """Test the is_local_only() function and SettingsService.local_only property."""
+
+    def _make_service(self, env_settings: dict):
+        """Create a SettingsService with mocked settings."""
+        import settings_service
+
+        settings = {"env": env_settings}
+        with patch.object(settings_service, "_cached_settings", settings):
+            return settings_service.SettingsService()
+
+    def test_local_only_true(self):
+        import settings_service
+
+        settings = {"env": {"local_only": True}}
+        with patch.object(settings_service, "_cached_settings", settings):
+            self.assertTrue(settings_service.is_local_only())
+
+    def test_local_only_false(self):
+        import settings_service
+
+        settings = {"env": {"local_only": False}}
+        with patch.object(settings_service, "_cached_settings", settings):
+            self.assertFalse(settings_service.is_local_only())
+
+    def test_local_only_missing_key_defaults_false(self):
+        import settings_service
+
+        settings = {"env": {"log_level": "DEBUG"}}
+        with patch.object(settings_service, "_cached_settings", settings):
+            self.assertFalse(settings_service.is_local_only())
+
+    def test_local_only_missing_env_section_defaults_false(self):
+        import settings_service
+
+        settings = {}
+        with patch.object(settings_service, "_cached_settings", settings):
+            self.assertFalse(settings_service.is_local_only())
+
+    def test_property_matches_function(self):
+        import settings_service
+
+        for value in (True, False):
+            settings = {"env": {"local_only": value}}
+            with patch.object(settings_service, "_cached_settings", settings):
+                svc = settings_service.SettingsService()
+                self.assertEqual(svc.local_only, settings_service.is_local_only())
+
+
+class TestSettingsTomlLocalOnlyDefault(unittest.TestCase):
+    """Ensure the committed settings.toml has local_only = false.
+
+    Prevents accidental deployment with sync disabled.
+    """
+
+    def test_local_only_is_false_in_committed_settings(self):
+        import tomllib
+
+        settings_path = Path(__file__).parent.parent / "settings.toml"
+        with open(settings_path, "rb") as f:
+            settings = tomllib.load(f)
+
+        self.assertFalse(
+            settings.get("env", {}).get("local_only", False),
+            "settings.toml must have local_only = false to prevent "
+            "accidental production deployment without sync",
+        )
+
+
+class TestSyncLocalOnlyMode(unittest.TestCase):
+    """Test DatabaseConfig.sync() behavior in local-only mode."""
+
+    @patch("settings_service.is_local_only", return_value=True)
+    @patch("init_db.verify_db_content", return_value=True)
+    def test_sync_returns_true_when_db_has_content(self, mock_verify, mock_local):
+        from config import DatabaseConfig
+
+        db = DatabaseConfig.__new__(DatabaseConfig)
+        db.alias = "wcmktprod"
+        db.path = "/fake/wcmktprod.db"
+        db.turso_url = None
+        db.token = None
+
+        result = db.sync()
+
+        self.assertTrue(result)
+        mock_verify.assert_called_once_with("/fake/wcmktprod.db")
+
+    @patch("settings_service.is_local_only", return_value=True)
+    @patch("init_db.verify_db_content", return_value=False)
+    def test_sync_returns_false_when_db_empty(self, mock_verify, mock_local):
+        from config import DatabaseConfig
+
+        db = DatabaseConfig.__new__(DatabaseConfig)
+        db.alias = "wcmktprod"
+        db.path = "/fake/wcmktprod.db"
+        db.turso_url = None
+        db.token = None
+
+        result = db.sync()
+
+        self.assertFalse(result)
+
+    @patch("settings_service.is_local_only", return_value=False)
+    def test_sync_raises_without_credentials_when_not_local_only(self, mock_local):
+        from config import DatabaseConfig
+
+        db = DatabaseConfig.__new__(DatabaseConfig)
+        db.alias = "wcmktprod"
+        db.path = "/fake/wcmktprod.db"
+        db.turso_url = None
+        db.token = None
+
+        with self.assertRaises(ValueError):
+            db.sync()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/sync_display.py
+++ b/ui/sync_display.py
@@ -17,8 +17,17 @@ logger = setup_logging(__name__, log_file="sync_display.log")
 
 def display_sync_status(language_code: str = "en"):
     """Display sync status in the sidebar."""
+    from settings_service import is_local_only
     from state.market_state import get_active_market
     active_alias = get_active_market().database_alias
+
+    if is_local_only():
+        st.sidebar.markdown(
+            "<span style='font-size: 14px; color: lightgrey;'>"
+            "*Local-only mode — sync disabled*</span>",
+            unsafe_allow_html=True,
+        )
+        return
 
     update_time: datetime | None = None
     time_since: timedelta | None = None

--- a/ui/sync_display.py
+++ b/ui/sync_display.py
@@ -18,8 +18,6 @@ logger = setup_logging(__name__, log_file="sync_display.log")
 def display_sync_status(language_code: str = "en"):
     """Display sync status in the sidebar."""
     from settings_service import is_local_only
-    from state.market_state import get_active_market
-    active_alias = get_active_market().database_alias
 
     if is_local_only():
         st.sidebar.markdown(
@@ -28,6 +26,9 @@ def display_sync_status(language_code: str = "en"):
             unsafe_allow_html=True,
         )
         return
+
+    from state.market_state import get_active_market
+    active_alias = get_active_market().database_alias
 
     update_time: datetime | None = None
     time_since: timedelta | None = None


### PR DESCRIPTION
This PR creates a local development mode that uses local databases only, bypassing database sync logicThis PR creates a local development mode that uses local databases only, bypassing database sync logic.