### PR TITLE
fix: downloads page respects active market context

### DIFF
--- a/config.py
+++ b/config.py
@@ -403,7 +403,7 @@ class DatabaseConfig:
                     os.remove(file_path)
                     logger.info(f"Removed {file_path} created during failed sync")
 
-    def get_table_list(self, local_only: bool = True) -> list[tuple]:
+    def get_table_list(self, local_only: bool = True) -> list[str]:
         if local_only:
             engine = self.engine
             with engine.connect() as conn:

--- a/pages/downloads.py
+++ b/pages/downloads.py
@@ -20,8 +20,7 @@ import pandas as pd
 
 from logging_config import setup_logging
 from config import DatabaseConfig
-from services import get_doctrine_service
-from services.doctrine_service import format_doctrine_name
+from services.doctrine_service import DoctrineService, format_doctrine_name
 from repositories import get_sde_repository
 from repositories.market_repo import MarketRepository
 from repositories.base import BaseRepository
@@ -60,9 +59,9 @@ def _get_market_history_csv(db_alias: str) -> bytes:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_all_doctrine_fits_csv() -> bytes:
+def _get_all_doctrine_fits_csv(db_alias: str) -> bytes:
     """Lazily load all doctrine fits data as CSV bytes."""
-    service = get_doctrine_service()
+    service = DoctrineService.create_default(db_alias)
     all_fits_df = service.build_fit_data().raw_df
     targets = service.repository.get_all_targets()
     data = all_fits_df.merge(targets, on='fit_id', how='left')
@@ -71,9 +70,9 @@ def _get_all_doctrine_fits_csv() -> bytes:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_fit_options() -> list[dict]:
+def _get_fit_options(db_alias: str) -> list[dict]:
     """Get list of fits for the dropdown."""
-    service = get_doctrine_service()
+    service = DoctrineService.create_default(db_alias)
     summaries = service.get_all_fit_summaries()
     return [
         {"fit_id": s.fit_id, "ship_name": s.ship_name, "fit_name": s.fit_name}
@@ -82,9 +81,9 @@ def _get_fit_options() -> list[dict]:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_doctrine_options() -> list[dict]:
+def _get_doctrine_options(db_alias: str) -> list[dict]:
     """Get list of doctrines for filtering."""
-    service = get_doctrine_service()
+    service = DoctrineService.create_default(db_alias)
     df = service.repository.get_all_doctrine_compositions()
     if df.empty:
         return []
@@ -98,9 +97,9 @@ def _get_doctrine_options() -> list[dict]:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_filtered_doctrine_csv(fit_ids: tuple) -> bytes:
+def _get_filtered_doctrine_csv(db_alias: str, fit_ids: tuple) -> bytes:
     """Get doctrine data filtered by fit_ids as CSV bytes."""
-    service = get_doctrine_service()
+    service = DoctrineService.create_default(db_alias)
     all_fits_df = service.build_fit_data().raw_df
     targets = service.repository.get_all_targets()
 
@@ -112,9 +111,9 @@ def _get_filtered_doctrine_csv(fit_ids: tuple) -> bytes:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_single_fit_csv(fit_id: int) -> bytes:
+def _get_single_fit_csv(db_alias: str, fit_id: int) -> bytes:
     """Get CSV bytes for a single fit."""
-    service = get_doctrine_service()
+    service = DoctrineService.create_default(db_alias)
     fit_df = service.repository.get_fit_by_id(fit_id)
     if fit_df.empty:
         return b""
@@ -239,6 +238,10 @@ def market_downloads_section():
 @st.fragment
 def doctrine_downloads_section():
     """Fragment for doctrine data downloads with filtering."""
+    from state.market_state import get_active_market
+    market = get_active_market()
+    db_alias = market.database_alias
+
     st.subheader("Doctrine Data Downloads", divider="orange")
     st.markdown("Download doctrine fit data. Filter by specific doctrine or download all fits.")
 
@@ -255,7 +258,7 @@ def doctrine_downloads_section():
 
     with col2:
         if filter_type == "By Doctrine":
-            doctrines = _get_doctrine_options()
+            doctrines = _get_doctrine_options(db_alias)
             doctrine_names = ["Select a doctrine..."] + sorted(
                 [d['doctrine_name'] for d in doctrines], key=format_doctrine_name
             )
@@ -272,15 +275,15 @@ def doctrine_downloads_section():
     if filter_type == "All Fits":
         st.download_button(
             "Download All Doctrine Fits",
-            data=_get_all_doctrine_fits_csv,
-            file_name="wc_doctrine_fits.csv",
+            data=lambda a=db_alias: _get_all_doctrine_fits_csv(a),
+            file_name=f"{market.short_name}_doctrine_fits.csv",
             mime="text/csv",
             use_container_width=True,
             icon=":material/download:"
         )
     else:
         if selected_doctrine and selected_doctrine != "Select a doctrine...":
-            doctrines = _get_doctrine_options()
+            doctrines = _get_doctrine_options(db_alias)
             doctrine_data = next((d for d in doctrines if d['doctrine_name'] == selected_doctrine), None)
 
             if doctrine_data:
@@ -289,7 +292,7 @@ def doctrine_downloads_section():
 
                 st.download_button(
                     f"Download {format_doctrine_name(selected_doctrine)}",
-                    data=lambda fids=fit_ids: _get_filtered_doctrine_csv(fids),
+                    data=lambda a=db_alias, fids=fit_ids: _get_filtered_doctrine_csv(a, fids),
                     file_name=f"doctrine_{safe_name}.csv",
                     mime="text/csv",
                     use_container_width=True,
@@ -300,10 +303,14 @@ def doctrine_downloads_section():
 @st.fragment
 def individual_fit_downloads_section():
     """Fragment for individual fit downloads."""
+    from state.market_state import get_active_market
+    market = get_active_market()
+    db_alias = market.database_alias
+
     st.subheader("Individual Fit Downloads", divider="green")
     st.markdown("Download detailed data for a specific fit.")
 
-    fits = _get_fit_options()
+    fits = _get_fit_options(db_alias)
     fit_options = {f"{f['ship_name']} (ID: {f['fit_id']})": f for f in fits}
 
     selected_fit_label = st.selectbox(
@@ -319,7 +326,7 @@ def individual_fit_downloads_section():
 
         st.download_button(
             f"Download Fit {fit_id}",
-            data=lambda fid=fit_id: _get_single_fit_csv(fid),
+            data=lambda a=db_alias, fid=fit_id: _get_single_fit_csv(a, fid),
             file_name=f"fit_{fit_id}_{ship_name}.csv",
             mime="text/csv",
             use_container_width=True,

--- a/pages/downloads.py
+++ b/pages/downloads.py
@@ -243,7 +243,7 @@ def doctrine_downloads_section():
     db_alias = market.database_alias
 
     st.subheader("Doctrine Data Downloads", divider="orange")
-    st.markdown("Download doctrine fit data. Filter by specific doctrine or download all fits.")
+    st.markdown(f"Download doctrine fit data with market data for **{market.name}**.")
 
     # Filter options
     col1, col2 = st.columns([1, 2])
@@ -308,7 +308,7 @@ def individual_fit_downloads_section():
     db_alias = market.database_alias
 
     st.subheader("Individual Fit Downloads", divider="green")
-    st.markdown("Download detailed data for a specific fit.")
+    st.markdown(f"Download detailed fit data with market data for **{market.name}**.")
 
     fits = _get_fit_options(db_alias)
     fit_options = {f"{f['ship_name']} (ID: {f['fit_id']})": f for f in fits}
@@ -342,7 +342,7 @@ def low_stock_downloads_section():
     db_alias = market.database_alias
 
     st.subheader("Low Stock Data Downloads", divider="red")
-    st.markdown("Download items that are running low on stock.")
+    st.markdown(f"Download items running low on stock at **{market.name}**.")
 
     col1, col2, col3 = st.columns(3)
 

--- a/pages/downloads.py
+++ b/pages/downloads.py
@@ -19,10 +19,11 @@ import streamlit as st
 import pandas as pd
 
 from logging_config import setup_logging
-from config import DatabaseConfig, get_settings
+from config import DatabaseConfig
 from services import get_doctrine_service
 from services.doctrine_service import format_doctrine_name
-from repositories import get_market_repository, get_sde_repository
+from repositories import get_sde_repository
+from repositories.market_repo import MarketRepository
 from repositories.base import BaseRepository
 from ui.market_selector import render_market_selector
 from init_db import ensure_market_db_ready
@@ -35,25 +36,25 @@ logger = setup_logging(__name__, log_file="downloads.log")
 
 
 @st.cache_data(ttl=1800, show_spinner=False)
-def _get_market_orders_csv() -> bytes:
+def _get_market_orders_csv(db_alias: str) -> bytes:
     """Lazily load and convert market orders to CSV bytes."""
-    repo = get_market_repository()
+    repo = MarketRepository(DatabaseConfig(db_alias))
     df = repo.get_all_orders()
     return df.to_csv(index=False).encode('utf-8')
 
 
 @st.cache_data(ttl=1800, show_spinner=False)
-def _get_market_stats_csv() -> bytes:
+def _get_market_stats_csv(db_alias: str) -> bytes:
     """Lazily load and convert market stats to CSV bytes."""
-    repo = get_market_repository()
+    repo = MarketRepository(DatabaseConfig(db_alias))
     df = repo.get_all_stats()
     return df.to_csv(index=False).encode('utf-8')
 
 
 @st.cache_data(ttl=1800, show_spinner=False)
-def _get_market_history_csv() -> bytes:
+def _get_market_history_csv(db_alias: str) -> bytes:
     """Lazily load and convert market history to CSV bytes."""
-    repo = get_market_repository()
+    repo = MarketRepository(DatabaseConfig(db_alias))
     df = repo.get_all_history()
     return df.to_csv(index=False).encode('utf-8')
 
@@ -121,10 +122,13 @@ def _get_single_fit_csv(fit_id: int) -> bytes:
 
 
 @st.cache_data(ttl=600, show_spinner=False)
-def _get_low_stock_csv(max_days: float, doctrine_only: bool, tech2_only: bool) -> bytes:
+def _get_low_stock_csv(
+    db_alias: str, max_days: float, doctrine_only: bool, tech2_only: bool
+) -> bytes:
     """Get low stock items as CSV bytes."""
-    mktdb = DatabaseConfig("wcmkt")
+    mktdb = DatabaseConfig(db_alias)
 
+    tech2_type_ids: list[int] = []
     if tech2_only:
         tech2_type_ids = get_sde_repository().get_tech2_type_ids()
 
@@ -146,11 +150,15 @@ def _get_low_stock_csv(max_days: float, doctrine_only: bool, tech2_only: bool) -
         df = df[df['days_remaining'] <= max_days]
 
     if not df.empty:
-        ship_groups = df.groupby('type_id', group_keys=False).apply(
-            lambda x: [f"{row['ship_name']} ({int(row['fits_on_mkt'])})"
-                      for _, row in x.iterrows()
-                      if pd.notna(row['ship_name']) and pd.notna(row['fits_on_mkt'])], include_groups=False
-        ).to_dict()
+        ship_groups: dict[int, list[str]] = {}
+        for type_id, group in df.groupby('type_id'):
+            ships = [
+                f"{row['ship_name']} ({int(row['fits_on_mkt'])})"
+                for _, row in group.iterrows()
+                if pd.notna(row['ship_name']) and pd.notna(row['fits_on_mkt'])
+            ]
+            if ships:
+                ship_groups[type_id] = ships  # type: ignore[index]
 
         df = df.drop_duplicates(subset=['type_id'])
         df['ships'] = df['type_id'].map(ship_groups)
@@ -188,9 +196,11 @@ def _get_sde_tables() -> list[str]:
 def market_downloads_section():
     """Section for market data downloads."""
     from state.market_state import get_active_market
-    short_name = get_active_market().short_name
+    market = get_active_market()
+    db_alias = market.database_alias
+    short_name = market.short_name
 
-    st.subheader("Market Data Downloads", divider="blue")
+    st.subheader(f"Market Data Downloads — {market.name}", divider="blue")
     st.markdown("Download market orders, statistics, and history data.")
 
     col1, col2, col3 = st.columns(3)
@@ -198,7 +208,7 @@ def market_downloads_section():
     with col1:
         st.download_button(
             "Download Market Orders",
-            data=_get_market_orders_csv,
+            data=lambda a=db_alias: _get_market_orders_csv(a),
             file_name=f"{short_name}_market_orders.csv",
             mime="text/csv",
             use_container_width=True,
@@ -208,7 +218,7 @@ def market_downloads_section():
     with col2:
         st.download_button(
             "Download Market Stats",
-            data=_get_market_stats_csv,
+            data=lambda a=db_alias: _get_market_stats_csv(a),
             file_name=f"{short_name}_market_stats.csv",
             mime="text/csv",
             use_container_width=True,
@@ -218,7 +228,7 @@ def market_downloads_section():
     with col3:
         st.download_button(
             "Download Market History",
-            data=_get_market_history_csv,
+            data=lambda a=db_alias: _get_market_history_csv(a),
             file_name=f"{short_name}_market_history.csv",
             mime="text/csv",
             use_container_width=True,
@@ -320,6 +330,10 @@ def individual_fit_downloads_section():
 @st.fragment
 def low_stock_downloads_section():
     """Fragment for low stock data downloads."""
+    from state.market_state import get_active_market
+    market = get_active_market()
+    db_alias = market.database_alias
+
     st.subheader("Low Stock Data Downloads", divider="red")
     st.markdown("Download items that are running low on stock.")
 
@@ -343,8 +357,8 @@ def low_stock_downloads_section():
 
     st.download_button(
         "Download Low Stock Items",
-        data=lambda md=max_days, do=doctrine_only, t2=tech2_only: _get_low_stock_csv(md, do, t2),
-        file_name="low_stock_items.csv",
+        data=lambda a=db_alias, md=max_days, do=doctrine_only, t2=tech2_only: _get_low_stock_csv(a, md, do, t2),
+        file_name=f"{market.short_name}_low_stock_items.csv",
         mime="text/csv",
         use_container_width=True,
         icon=":material/download:"

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -138,6 +138,83 @@ class TestLowStockCsvMarketContext:
         mock_db_cls.assert_called_once_with("wcmktprod")
 
 
+class TestDoctrineDownloadsCsv:
+    """Test that doctrine CSV functions use the provided db_alias."""
+
+    @patch("pages.downloads.DoctrineService")
+    def test_all_doctrine_fits_csv_uses_provided_alias(self, mock_svc_cls):
+        """_get_all_doctrine_fits_csv passes db_alias to DoctrineService.create_default."""
+        mock_service = Mock()
+        mock_service.build_fit_data.return_value.raw_df = pd.DataFrame({
+            "fit_id": [1], "type_id": [34], "qty": [1]
+        })
+        mock_service.repository.get_all_targets.return_value = pd.DataFrame({
+            "fit_id": [1], "target": [10]
+        })
+        mock_svc_cls.create_default.return_value = mock_service
+
+        from pages.downloads import _get_all_doctrine_fits_csv
+        _get_all_doctrine_fits_csv.clear()
+        result = _get_all_doctrine_fits_csv("wcmktnorth")
+
+        mock_svc_cls.create_default.assert_called_once_with("wcmktnorth")
+        assert b"fit_id" in result
+
+    @patch("pages.downloads.DoctrineService")
+    def test_fit_options_uses_provided_alias(self, mock_svc_cls):
+        """_get_fit_options passes db_alias to DoctrineService.create_default."""
+        mock_summary = Mock()
+        mock_summary.fit_id = 1
+        mock_summary.ship_name = "Osprey"
+        mock_summary.fit_name = "Logi"
+        mock_service = Mock()
+        mock_service.get_all_fit_summaries.return_value = [mock_summary]
+        mock_svc_cls.create_default.return_value = mock_service
+
+        from pages.downloads import _get_fit_options
+        _get_fit_options.clear()
+        result = _get_fit_options("wcmktnorth")
+
+        mock_svc_cls.create_default.assert_called_once_with("wcmktnorth")
+        assert len(result) == 1
+        assert result[0]["ship_name"] == "Osprey"
+
+    @patch("pages.downloads.DoctrineService")
+    def test_single_fit_csv_uses_provided_alias(self, mock_svc_cls):
+        """_get_single_fit_csv passes db_alias to DoctrineService.create_default."""
+        mock_service = Mock()
+        mock_service.repository.get_fit_by_id.return_value = pd.DataFrame({
+            "fit_id": [1], "type_id": [34]
+        })
+        mock_svc_cls.create_default.return_value = mock_service
+
+        from pages.downloads import _get_single_fit_csv
+        _get_single_fit_csv.clear()
+        result = _get_single_fit_csv("wcmktprod", 1)
+
+        mock_svc_cls.create_default.assert_called_once_with("wcmktprod")
+        assert b"fit_id" in result
+
+    @patch("pages.downloads.DoctrineService")
+    def test_filtered_doctrine_csv_uses_provided_alias(self, mock_svc_cls):
+        """_get_filtered_doctrine_csv passes db_alias to DoctrineService.create_default."""
+        mock_service = Mock()
+        mock_service.build_fit_data.return_value.raw_df = pd.DataFrame({
+            "fit_id": [1, 2], "type_id": [34, 35], "qty": [1, 2]
+        })
+        mock_service.repository.get_all_targets.return_value = pd.DataFrame({
+            "fit_id": [1, 2], "target": [10, 20]
+        })
+        mock_svc_cls.create_default.return_value = mock_service
+
+        from pages.downloads import _get_filtered_doctrine_csv
+        _get_filtered_doctrine_csv.clear()
+        result = _get_filtered_doctrine_csv("wcmktnorth", (1,))
+
+        mock_svc_cls.create_default.assert_called_once_with("wcmktnorth")
+        assert b"fit_id" in result
+
+
 class TestGetTableListReturnType:
     """Test that get_table_list returns list[str]."""
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,176 @@
+"""
+Tests for pages/downloads.py
+
+Verifies that download functions respect the active market context
+by passing the correct database alias through to repositories.
+"""
+import pytest
+import pandas as pd
+from unittest.mock import Mock, patch, PropertyMock, MagicMock
+
+
+class TestMarketDownloadsCsv:
+    """Test that market CSV functions use the provided db_alias."""
+
+    def _mock_db_and_repo(self, df: pd.DataFrame):
+        """Create mocked DatabaseConfig and MarketRepository returning df."""
+        mock_db = Mock()
+        mock_db.alias = "test_alias"
+        mock_repo = Mock()
+        mock_repo.get_all_orders.return_value = df
+        mock_repo.get_all_stats.return_value = df
+        mock_repo.get_all_history.return_value = df
+        return mock_db, mock_repo
+
+    @patch("pages.downloads.MarketRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_market_orders_csv_uses_provided_alias(self, mock_db_cls, mock_repo_cls):
+        """_get_market_orders_csv passes db_alias to DatabaseConfig."""
+        df = pd.DataFrame({"type_id": [34], "price": [10.0]})
+        mock_db, mock_repo = self._mock_db_and_repo(df)
+        mock_db_cls.return_value = mock_db
+        mock_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_market_orders_csv
+        _get_market_orders_csv.clear()
+        result = _get_market_orders_csv("wcmktprod")
+
+        mock_db_cls.assert_called_once_with("wcmktprod")
+        mock_repo_cls.assert_called_once_with(mock_db)
+        assert b"type_id" in result
+        assert b"34" in result
+
+    @patch("pages.downloads.MarketRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_market_orders_csv_different_alias(self, mock_db_cls, mock_repo_cls):
+        """Different db_alias produces a different DatabaseConfig call."""
+        df = pd.DataFrame({"type_id": [99], "price": [5.0]})
+        mock_db, mock_repo = self._mock_db_and_repo(df)
+        mock_db_cls.return_value = mock_db
+        mock_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_market_orders_csv
+        _get_market_orders_csv.clear()
+        _get_market_orders_csv("wcmktnorth")
+
+        mock_db_cls.assert_called_once_with("wcmktnorth")
+
+    @patch("pages.downloads.MarketRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_market_stats_csv_uses_provided_alias(self, mock_db_cls, mock_repo_cls):
+        """_get_market_stats_csv passes db_alias to DatabaseConfig."""
+        df = pd.DataFrame({"type_id": [34], "sell_volume": [100]})
+        mock_db, mock_repo = self._mock_db_and_repo(df)
+        mock_db_cls.return_value = mock_db
+        mock_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_market_stats_csv
+        _get_market_stats_csv.clear()
+        _get_market_stats_csv("wcmktnorth")
+
+        mock_db_cls.assert_called_once_with("wcmktnorth")
+
+    @patch("pages.downloads.MarketRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_market_history_csv_uses_provided_alias(self, mock_db_cls, mock_repo_cls):
+        """_get_market_history_csv passes db_alias to DatabaseConfig."""
+        df = pd.DataFrame({"type_id": [34], "date": ["2024-01-01"]})
+        mock_db, mock_repo = self._mock_db_and_repo(df)
+        mock_db_cls.return_value = mock_db
+        mock_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_market_history_csv
+        _get_market_history_csv.clear()
+        _get_market_history_csv("wcmktprod")
+
+        mock_db_cls.assert_called_once_with("wcmktprod")
+
+
+class TestLowStockCsvMarketContext:
+    """Test that low stock CSV function uses the provided db_alias."""
+
+    @patch("pages.downloads.BaseRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_low_stock_csv_uses_provided_alias(self, mock_db_cls, mock_base_repo_cls):
+        """_get_low_stock_csv passes db_alias to DatabaseConfig, not hardcoded."""
+        mock_db = Mock()
+        mock_db_cls.return_value = mock_db
+
+        df = pd.DataFrame({
+            "type_id": [34],
+            "days_remaining": [3.0],
+            "is_doctrine": [0],
+            "ship_name": [None],
+            "fits_on_mkt": [None],
+        })
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = df
+        mock_base_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_low_stock_csv
+        _get_low_stock_csv.clear()
+        _get_low_stock_csv("wcmktnorth", 7.0, False, False)
+
+        mock_db_cls.assert_called_once_with("wcmktnorth")
+
+    @patch("pages.downloads.BaseRepository")
+    @patch("pages.downloads.DatabaseConfig")
+    def test_low_stock_csv_primary_alias(self, mock_db_cls, mock_base_repo_cls):
+        """Verify primary market alias is passed through correctly."""
+        mock_db = Mock()
+        mock_db_cls.return_value = mock_db
+
+        df = pd.DataFrame({
+            "type_id": [34],
+            "days_remaining": [3.0],
+            "is_doctrine": [0],
+            "ship_name": [None],
+            "fits_on_mkt": [None],
+        })
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = df
+        mock_base_repo_cls.return_value = mock_repo
+
+        from pages.downloads import _get_low_stock_csv
+        _get_low_stock_csv.clear()
+        _get_low_stock_csv("wcmktprod", 7.0, False, False)
+
+        mock_db_cls.assert_called_once_with("wcmktprod")
+
+
+class TestGetTableListReturnType:
+    """Test that get_table_list returns list[str]."""
+
+    @patch("config.DatabaseConfig.engine", new_callable=PropertyMock)
+    def test_get_table_list_returns_list_of_strings(self, mock_engine_prop):
+        """get_table_list should return list[str], not list[tuple]."""
+        mock_conn = MagicMock()
+        mock_row1 = Mock()
+        mock_row1.name = "marketstats"
+        mock_row2 = Mock()
+        mock_row2.name = "marketorders"
+        mock_row3 = Mock()
+        mock_row3.name = "sqlite_stat1"
+        mock_conn.execute.return_value.fetchall.return_value = [
+            mock_row1, mock_row2, mock_row3
+        ]
+        mock_conn.__enter__ = Mock(return_value=mock_conn)
+        mock_conn.__exit__ = Mock(return_value=None)
+
+        mock_engine = Mock()
+        mock_engine.connect.return_value = mock_conn
+        mock_engine_prop.return_value = mock_engine
+
+        from config import DatabaseConfig
+        with patch.object(DatabaseConfig, '__init__', lambda self, *a, **kw: None):
+            db = DatabaseConfig.__new__(DatabaseConfig)
+            db._engine = mock_engine
+            # Manually set engine property to return our mock
+            with patch.object(type(db), 'engine', new_callable=PropertyMock, return_value=mock_engine):
+                result = db.get_table_list()
+
+        assert isinstance(result, list)
+        assert all(isinstance(t, str) for t in result)
+        assert "marketstats" in result
+        assert "marketorders" in result
+        assert "sqlite_stat1" not in result


### PR DESCRIPTION
## Summary
- **Fixed market data leak across hubs**: All download functions (`_get_market_orders_csv`, `_get_market_stats_csv`, `_get_market_history_csv`, `_get_all_doctrine_fits_csv`, `_get_fit_options`, `_get_doctrine_options`, `_get_filtered_doctrine_csv`, `_get_single_fit_csv`, `_get_low_stock_csv`) used `@st.cache_data` without a `db_alias` parameter, so Streamlit cached a single result shared across all markets. Added `db_alias: str` to each function so each market gets its own cache entry.
- **Fixed hardcoded database in low stock**: `_get_low_stock_csv` used `DatabaseConfig("wcmkt")` instead of the active market's alias.
- **Explicit market context in UI**: Each download section now shows the active market name (e.g. "4-HWWF Keepstar Market") so users know which market's data they're downloading.
- **Fixed pyright issues**: Initialized `tech2_type_ids` before conditional use, replaced `groupby.apply(include_groups=False)` with explicit loop, fixed `get_table_list` return type annotation (`list[tuple]` → `list[str]`).
- **Added 11 tests** verifying correct `db_alias` is passed through for market, doctrine, and low stock downloads.

## Test plan
- [x] `uv run pytest tests/test_downloads.py -v` — 11 tests pass
- [x] `uv run pytest -q` — 247 passed, 1 pre-existing unrelated failure
- [x] Manual: switch between 4H and B9 markets, download CSV files, verify data matches selected market
- [x] Verify section headers show correct market name when switching hubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)