### PR TITLE
fix: clear downloads page CSV caches after DB sync

### DIFF
--- a/pages/downloads.py
+++ b/pages/downloads.py
@@ -289,6 +289,27 @@ def _get_sde_tables() -> list[str]:
     return db.get_table_list()
 
 
+def clear_download_caches() -> None:
+    """Clear market/doctrine-scoped CSV caches on this page.
+
+    Called by ``state.market_state.refresh_market_caches()`` after a DB sync.
+    SDE caches are intentionally excluded — SDE does not change on market sync.
+    """
+    for fn in (
+        _get_market_orders_csv,
+        _get_market_stats_csv,
+        _get_market_history_csv,
+        _get_all_doctrine_fits_csv,
+        _get_low_stock_doctrine_fits_csv,
+        _get_fit_options,
+        _get_doctrine_options,
+        _get_filtered_doctrine_csv,
+        _get_single_fit_csv,
+        _get_low_stock_csv,
+    ):
+        fn.clear()
+
+
 # =============================================================================
 # UI Sections
 # =============================================================================

--- a/state/market_state.py
+++ b/state/market_state.py
@@ -154,8 +154,8 @@ def refresh_market_caches() -> None:
     try:
         from pages.downloads import clear_download_caches
         clear_download_caches()
-    except ImportError:
-        pass
+    except ImportError as e:
+        logger.debug(f"Skipping download cache clear: {e}")
 
     # Clear DoctrineService's in-memory _cached_result on the cached singleton
     # for the active market, without creating one if none exists.

--- a/state/market_state.py
+++ b/state/market_state.py
@@ -148,6 +148,15 @@ def refresh_market_caches() -> None:
     except ImportError:
         pass
 
+    # Clear download page CSV caches (market/doctrine-scoped only; SDE excluded).
+    # These are dual-layer: page caches wrap repo caches, so clearing only repo
+    # caches leaves stale CSV bytes until page-level TTL expires.
+    try:
+        from pages.downloads import clear_download_caches
+        clear_download_caches()
+    except ImportError:
+        pass
+
     # Clear DoctrineService's in-memory _cached_result on the cached singleton
     # for the active market, without creating one if none exists.
     service_key = f"doctrine_service_{get_active_market_key()}"

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -216,6 +216,69 @@ class TestDoctrineDownloadsCsv:
         assert b"fit_id" in result
 
 
+class TestClearDownloadCaches:
+    """Regression tests for post-sync cache invalidation.
+
+    The downloads page wraps already-cached repo calls in its own
+    @st.cache_data layer. Without targeted invalidation in
+    refresh_market_caches(), users saw stale CSVs until the TTL expired
+    (up to 30 min).
+    """
+
+    _MARKET_SCOPED_FNS = (
+        "_get_market_orders_csv",
+        "_get_market_stats_csv",
+        "_get_market_history_csv",
+        "_get_all_doctrine_fits_csv",
+        "_get_low_stock_doctrine_fits_csv",
+        "_get_fit_options",
+        "_get_doctrine_options",
+        "_get_filtered_doctrine_csv",
+        "_get_single_fit_csv",
+        "_get_low_stock_csv",
+    )
+    _SDE_SCOPED_FNS = ("_get_sde_table_csv", "_get_sde_tables")
+
+    def test_clears_all_market_and_doctrine_caches(self):
+        """clear_download_caches() calls .clear() on every market-scoped CSV fn."""
+        import pages.downloads as downloads
+        patches = {name: patch.object(downloads, name) for name in self._MARKET_SCOPED_FNS}
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            downloads.clear_download_caches()
+            for name, m in mocks.items():
+                m.clear.assert_called_once()
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_leaves_sde_caches_untouched(self):
+        """SDE caches are invariant across market syncs and must not be cleared."""
+        import pages.downloads as downloads
+        patches = {name: patch.object(downloads, name) for name in self._SDE_SCOPED_FNS}
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            downloads.clear_download_caches()
+            for name, m in mocks.items():
+                m.clear.assert_not_called()
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    @patch("pages.downloads.clear_download_caches")
+    def test_refresh_market_caches_invokes_download_clear(self, mock_clear):
+        """refresh_market_caches() must call clear_download_caches() post-sync.
+
+        This guards against the original bug: repo caches cleared but page-level
+        CSV caches left stale until TTL expiry.
+        """
+        from state.market_state import refresh_market_caches
+
+        refresh_market_caches()
+
+        mock_clear.assert_called_once()
+
+
 class TestGetTableListReturnType:
     """Test that get_table_list returns list[str]."""
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -221,8 +221,8 @@ class TestClearDownloadCaches:
 
     The downloads page wraps already-cached repo calls in its own
     @st.cache_data layer. Without targeted invalidation in
-    refresh_market_caches(), users saw stale CSVs until the TTL expired
-    (up to 30 min).
+    refresh_market_caches(), users saw stale CSVs until the page-level
+    TTL expired.
     """
 
     _MARKET_SCOPED_FNS = (


### PR DESCRIPTION
## Summary

- Users reported downloads page showing stale data for "a few minutes" after a DB sync — caused by `pages/downloads.py` wrapping repo calls in its own `@st.cache_data` layer (TTL 600-1800s) that wasn't cleared post-sync
- Add `clear_download_caches()` and wire it into `refresh_market_caches()` via the existing deferred-import pattern (mirrors how `market_repo`, `doctrine_repo`, and `module_equivalents_service` caches are cleared)
- SDE caches (`_get_sde_table_csv`, `_get_sde_tables`) are intentionally excluded — SDE data does not change on a market sync

## Root cause

The post-sync chain is `check_db → refresh_market_caches → st.rerun()`. `refresh_market_caches()` cleared 3 layers of repo/service caches, but the downloads page has 10 market/doctrine-scoped `@st.cache_data` functions that generate CSV bytes. Because they key on `db_alias` (stable across syncs), Streamlit returned the cached bytes without re-invoking the (now-fresh) repo. The "few minutes later" symptom matched the 600-1800s TTL expiry exactly.

## Test plan

- [x] Added 3 regression tests in `tests/test_downloads.py::TestClearDownloadCaches`:
  - `test_clears_all_market_and_doctrine_caches` — every market-scoped CSV fn's `.clear()` is called
  - `test_leaves_sde_caches_untouched` — SDE `.clear()` is NOT called
  - `test_refresh_market_caches_invokes_download_clear` — wiring regression guard
- [x] Full suite green: `uv run pytest -q` → 247 passed, 16 subtests passed
- [x] Ruff clean on modified files
- [x] Manual verification: trigger a sync with fresh remote data, click Download Market Orders within 30 min — CSV reflects post-sync state rather than pre-sync cached bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)