### PR TITLE
feat(sync): support buildcost.db in periodic sync via freshness probe

### DIFF
--- a/build_cost_models.py
+++ b/build_cost_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Integer, String, Float, DateTime
+from sqlalchemy import Integer, String, Float, DateTime, Index
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -72,6 +72,11 @@ class UpdateLog(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     table_name: Mapped[str] = mapped_column(String)
     timestamp: Mapped[datetime] = mapped_column(DateTime)
+
+    # Freshness-probe access pattern: lookup by table_name, read timestamp.
+    __table_args__ = (
+        Index("ix_updatelog_table_name", "table_name"),
+    )
 
     def __repr__(self) -> str:
         return (

--- a/build_cost_models.py
+++ b/build_cost_models.py
@@ -1,45 +1,84 @@
-from sqlalchemy import Column, Integer, String, Float
-from sqlalchemy.orm import declarative_base
+from datetime import datetime
+from sqlalchemy import Integer, String, Float, DateTime
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
+
 
 class Structure(Base):
     __tablename__ = "structures"
-    system = Column(String, nullable=True)
-    structure = Column(String, nullable=True)
-    system_id = Column(Integer, nullable=True)
-    structure_id = Column(Integer, primary_key=True)
-    rig_1 = Column(String, nullable=True)
-    rig_2 = Column(String, nullable=True)
-    rig_3 = Column(String, nullable=True)
-    structure_type = Column(String, nullable=True)
-    structure_type_id = Column(Integer, nullable=True)
-    tax = Column(Float, nullable=True)
-    region = Column(String, nullable=True)
-    region_id = Column(Integer, nullable=True)
-    def __repr__(self):
-        return f"<Structure(system={self.system}, structure={self.structure}, system_id={self.system_id}, structure_id={self.structure_id}, rig_1={self.rig_1}, rig_2={self.rig_2}, rig_3={self.rig_3}, structure_type={self.structure_type}, structure_type_id={self.structure_type_id}, tax={self.tax}, region={self.region}, region_id={self.region_id})>"
+    system: Mapped[str | None] = mapped_column(String, nullable=True)
+    structure: Mapped[str | None] = mapped_column(String, nullable=True)
+    system_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    structure_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    rig_1: Mapped[str | None] = mapped_column(String, nullable=True)
+    rig_2: Mapped[str | None] = mapped_column(String, nullable=True)
+    rig_3: Mapped[str | None] = mapped_column(String, nullable=True)
+    structure_type: Mapped[str | None] = mapped_column(String, nullable=True)
+    structure_type_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tax: Mapped[float | None] = mapped_column(Float, nullable=True)
+    region: Mapped[str | None] = mapped_column(String, nullable=True)
+    region_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<Structure(system={self.system}, structure={self.structure}, "
+            f"system_id={self.system_id}, structure_id={self.structure_id}, "
+            f"rig_1={self.rig_1}, rig_2={self.rig_2}, rig_3={self.rig_3}, "
+            f"structure_type={self.structure_type}, "
+            f"structure_type_id={self.structure_type_id}, tax={self.tax}, "
+            f"region={self.region}, region_id={self.region_id})>"
+        )
+
 
 class IndustryIndex(Base):
     __tablename__ = "industry_index"
-    solar_system_id = Column(Integer, primary_key=True)
-    manufacturing = Column(Float)
-    researching_time_efficiency = Column(Float)
-    researching_material_efficiency = Column(Float)
-    copying = Column(Float)
-    invention = Column(Float)
-    reaction = Column(Float)
+    solar_system_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    manufacturing: Mapped[float] = mapped_column(Float)
+    researching_time_efficiency: Mapped[float] = mapped_column(Float)
+    researching_material_efficiency: Mapped[float] = mapped_column(Float)
+    copying: Mapped[float] = mapped_column(Float)
+    invention: Mapped[float] = mapped_column(Float)
+    reaction: Mapped[float] = mapped_column(Float)
 
-    def __repr__(self):
-        return f"<IndustryIndex(solar_system_id={self.solar_system_id}, manufacturing={self.manufacturing}, researching_time_efficiency={self.researching_time_efficiency}, researching_material_efficiency={self.researching_material_efficiency}, copying={self.copying}, invention={self.invention}, reaction={self.reaction})>"
+    def __repr__(self) -> str:
+        return (
+            f"<IndustryIndex(solar_system_id={self.solar_system_id}, "
+            f"manufacturing={self.manufacturing}, "
+            f"researching_time_efficiency={self.researching_time_efficiency}, "
+            f"researching_material_efficiency={self.researching_material_efficiency}, "
+            f"copying={self.copying}, invention={self.invention}, "
+            f"reaction={self.reaction})>"
+        )
+
+
 class Rig(Base):
     __tablename__ = "rigs"
-    type_id = Column(Integer, primary_key=True)
-    type_name = Column(String)
-    icon_id = Column(Integer)
+    type_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    type_name: Mapped[str] = mapped_column(String)
+    icon_id: Mapped[int] = mapped_column(Integer)
 
-    def __repr__(self):
-        return f"<Rig(type_id={self.type_id}, type_name={self.type_name}, icon_id={self.icon_id})>"
+    def __repr__(self) -> str:
+        return (
+            f"<Rig(type_id={self.type_id}, type_name={self.type_name}, "
+            f"icon_id={self.icon_id})>"
+        )
+
+
+class UpdateLog(Base):
+    __tablename__ = "updatelog"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    table_name: Mapped[str] = mapped_column(String)
+    timestamp: Mapped[datetime] = mapped_column(DateTime)
+
+    def __repr__(self) -> str:
+        return (
+            f"<UpdateLog(id={self.id!r}, table_name={self.table_name!r}, "
+            f"timestamp={self.timestamp!r})>"
+        )
+
 
 if __name__ == "__main__":
     pass

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
-from sqlalchemy import create_engine, text, select, NullPool
+from sqlalchemy import create_engine, inspect, text, select, NullPool
+from sqlalchemy.exc import NoSuchTableError, OperationalError
 import streamlit as st
 import os
 
@@ -365,65 +366,77 @@ class DatabaseConfig:
         except Exception:
             return False
 
+    def _update_log_cls(self):
+        """Return the ``UpdateLog`` ORM class bound to this alias's ``Base``.
+
+        Each database has its own ``DeclarativeBase`` registry, so the
+        ``UpdateLog`` model lives alongside the rest of that database's
+        models (e.g. ``models.UpdateLog`` for market DBs,
+        ``build_cost_models.UpdateLog`` for build_cost).  Returns ``None``
+        when no probe is configured for this alias.
+        """
+        if not self.probe_table:
+            return None
+        if self.alias == "build_cost":
+            from build_cost_models import UpdateLog
+            return UpdateLog
+        from models import UpdateLog
+        return UpdateLog
+
     def local_matches_remote(self) -> bool:
         """Check if local updatelog timestamp matches remote after sync.
 
-        Probes the row whose ``table_name`` matches ``self.probe_table``
-        (configured in ``settings.toml`` ``[freshness_probes]``).  When no
-        probe is configured for this alias the check is skipped and True
-        is returned — sync is trusted as soon as libsql reports success.
+        Probes the single ``updatelog`` row whose ``table_name`` matches
+        ``self.probe_table`` (configured in ``settings.toml``
+        ``[freshness_probes]``).  When no probe is configured for this
+        alias the check is skipped and True is returned — sync is trusted
+        as soon as libsql reports success.
 
-        Returns True when the probe is not yet operational on the remote
-        (table missing, no row for this probe).  This avoids spamming
-        useless syncs before the backend has shipped its first updatelog
-        write.  Returns False only when remote has a probe row and local
-        either lacks it or has an older timestamp.
-
-        Uses a plain sqlite3 read-only connection for the local read to
-        avoid any SQLAlchemy connection pool caching or replica-state issues.
+        Returns True only when the probe is genuinely "not deployed yet":
+        the remote ``updatelog`` table is missing, or it exists but has
+        no row for this probe.  Returns False on local read failure or
+        when local and remote timestamps differ.  Connection-class errors
+        (auth, network, TLS, etc.) propagate to the caller so a real
+        failure is surfaced instead of masked as "synced".
         """
-        if not self.probe_table:
+        UpdateLog = self._update_log_cls()
+        if UpdateLog is None:
             return True
 
-        # Read remote via Turso.  Treat any failure (table missing,
-        # connection drop) as "probe not operational" → skip the check.
-        try:
-            with self.remote_engine.connect() as conn:
-                row = conn.execute(
-                    text(
-                        "SELECT MAX(timestamp) FROM updatelog "
-                        "WHERE table_name = :probe"
-                    ),
-                    {"probe": self.probe_table},
-                ).fetchone()
-                remote_ts = row[0] if row else None
-        except Exception as e:
-            logger.info(
+        # Pre-check that the remote probe table exists.  Doing this via
+        # the inspector means a missing table is a clean boolean signal
+        # rather than a connection-class OperationalError, so we can let
+        # auth/network failures from the actual query propagate naturally
+        # without swallowing them through error-type guessing.
+        if not inspect(self.remote_engine).has_table("updatelog"):
+            logger.warning(
                 f"local_matches_remote({self.alias}, probe={self.probe_table}): "
-                f"remote probe unavailable ({e}); skipping freshness check"
+                "remote updatelog table absent; skipping freshness check"
             )
             return True
+
+        stmt = select(UpdateLog.timestamp).where(
+            UpdateLog.table_name == self.probe_table
+        )
+
+        with Session(self.remote_engine) as session:
+            remote_ts = session.execute(stmt).scalar()
 
         if remote_ts is None:
-            logger.info(
+            logger.warning(
                 f"local_matches_remote({self.alias}, probe={self.probe_table}): "
-                f"no remote probe row yet; skipping freshness check"
+                "no remote probe row yet; skipping freshness check"
             )
             return True
 
-        # Read local via plain sqlite3 (bypasses libsql driver entirely).
+        # Local read fails closed: a missing table, malformed disk, or
+        # any other DB error post-sync means sync didn't deliver usable
+        # data, so the caller should resync.
         try:
-            local_conn = sql.connect(f"file:{self.path}?mode=ro", uri=True)
-            try:
-                row = local_conn.execute(
-                    "SELECT MAX(timestamp) FROM updatelog WHERE table_name = ?",
-                    (self.probe_table,),
-                ).fetchone()
-                local_ts = row[0] if row else None
-            finally:
-                local_conn.close()
-        except Exception as e:
-            logger.warning(
+            with Session(self.ro_engine) as session:
+                local_ts = session.execute(stmt).scalar()
+        except (OperationalError, NoSuchTableError) as e:
+            logger.error(
                 f"local_matches_remote({self.alias}) local read failed: {e}"
             )
             return False
@@ -508,46 +521,35 @@ class DatabaseConfig:
             conn.close()
             return column_info
 
-    def get_most_recent_update(self, table_name: str, remote: bool = False) -> datetime:
-        """
-        Get the most recent update time for a specific table
+    def get_most_recent_update(
+        self,
+        table_name: str,
+        update_log_cls,
+        remote: bool = False,
+    ) -> datetime | None:
+        """Return the updatelog timestamp for ``table_name``, or None if absent.
+
         Args:
-            table_name: str - The name of the table to get the most recent update time for
-            remote: bool - If True, get the most recent update time from the remote database, if False, get the most recent update time from the local database
+            table_name: Value to match against ``updatelog.table_name``.
+            update_log_cls: ORM ``UpdateLog`` class bound to the correct
+                ``Base``.  Callers pass the class from the module that
+                owns this database's models (e.g. ``models.UpdateLog`` for
+                market DBs, ``build_cost_models.UpdateLog`` for build_cost).
+            remote: Read from the Turso remote engine when True.
 
-        Returns:
-            The most recent update time for the table
+        Returns the timestamp as a tz-aware UTC ``datetime``, or None when
+        no row matches.  The column is stored as a naive datetime; UTC is
+        the contract enforced by the backend writer.
         """
-        from models import UpdateLog
-
         engine = self.remote_engine if remote else self.engine
-        session = Session(bind=engine)
-        with session.begin():
-            updates = (
-                select(UpdateLog.timestamp)
-                .where(UpdateLog.table_name == table_name)
-                .order_by(UpdateLog.timestamp.desc())
+        with Session(bind=engine) as session:
+            stmt = select(update_log_cls.timestamp).where(
+                update_log_cls.table_name == table_name
             )
-            result = session.execute(updates).fetchone()
-            update_time = result[0] if result is not None else None
-            update_time = (
-                update_time.replace(tzinfo=timezone.utc)
-                if update_time is not None
-                else None
-            )
-        session.close()
-        engine.dispose()
-        return update_time
-
-    def get_time_since_update(
-        self, table_name: str = "marketstats", remote: bool = False
-    ):
-        status = self.get_most_recent_update(table_name, remote=remote)
-        now = datetime.now(tz=timezone.utc)
-        time_since = now - status
-        logger.info(f"update_time: {status.strftime('%Y-%m-%d %H:%M')}")
-        logger.info(f"time_since: {round(time_since.total_seconds() / 60, 1)} minutes")
-        return time_since if time_since is not None else None
+            update_time = session.execute(stmt).scalar()
+        if update_time is None:
+            return None
+        return update_time.replace(tzinfo=timezone.utc)
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -60,6 +60,10 @@ class DatabaseConfig:
         except (KeyError, AttributeError):
             pass  # Not all aliases need Turso (graceful degradation)
 
+    # Per-alias probe table for post-sync freshness validation.
+    # Empty mapping means "skip the probe and trust libsql sync".
+    _freshness_probes: dict[str, str] = settings.get("freshness_probes", {})
+
     # Shared handles per-alias to avoid multiple simultaneous connections to the same file
     _engines: dict[str, object] = {}
     _remote_engines: dict[str, object] = {}
@@ -98,6 +102,7 @@ class DatabaseConfig:
         turso_key = f"{self.alias}_turso"
         self.turso_url = self._db_turso_urls.get(turso_key)
         self.token = self._db_turso_auth_tokens.get(turso_key)
+        self.probe_table = self._freshness_probes.get(self.alias)
         self._engine = None
         self._remote_engine = None
         self._libsql_connect = None
@@ -363,36 +368,71 @@ class DatabaseConfig:
     def local_matches_remote(self) -> bool:
         """Check if local updatelog timestamp matches remote after sync.
 
+        Probes the row whose ``table_name`` matches ``self.probe_table``
+        (configured in ``settings.toml`` ``[freshness_probes]``).  When no
+        probe is configured for this alias the check is skipped and True
+        is returned — sync is trusted as soon as libsql reports success.
+
+        Returns True when the probe is not yet operational on the remote
+        (table missing, no row for this probe).  This avoids spamming
+        useless syncs before the backend has shipped its first updatelog
+        write.  Returns False only when remote has a probe row and local
+        either lacks it or has an older timestamp.
+
         Uses a plain sqlite3 read-only connection for the local read to
         avoid any SQLAlchemy connection pool caching or replica-state issues.
-        Returns False on any error (missing table, connection failure, etc.).
         """
+        if not self.probe_table:
+            return True
+
+        # Read remote via Turso.  Treat any failure (table missing,
+        # connection drop) as "probe not operational" → skip the check.
         try:
-            # Read remote via Turso
             with self.remote_engine.connect() as conn:
                 row = conn.execute(
-                    text("SELECT timestamp FROM updatelog WHERE table_name = 'marketstats'")
+                    text(
+                        "SELECT MAX(timestamp) FROM updatelog "
+                        "WHERE table_name = :probe"
+                    ),
+                    {"probe": self.probe_table},
                 ).fetchone()
                 remote_ts = row[0] if row else None
+        except Exception as e:
+            logger.info(
+                f"local_matches_remote({self.alias}, probe={self.probe_table}): "
+                f"remote probe unavailable ({e}); skipping freshness check"
+            )
+            return True
 
-            # Read local via plain sqlite3 (bypasses libsql driver entirely)
+        if remote_ts is None:
+            logger.info(
+                f"local_matches_remote({self.alias}, probe={self.probe_table}): "
+                f"no remote probe row yet; skipping freshness check"
+            )
+            return True
+
+        # Read local via plain sqlite3 (bypasses libsql driver entirely).
+        try:
             local_conn = sql.connect(f"file:{self.path}?mode=ro", uri=True)
             try:
                 row = local_conn.execute(
-                    "SELECT timestamp FROM updatelog WHERE table_name = 'marketstats'"
+                    "SELECT MAX(timestamp) FROM updatelog WHERE table_name = ?",
+                    (self.probe_table,),
                 ).fetchone()
                 local_ts = row[0] if row else None
             finally:
                 local_conn.close()
-
-            logger.info(
-                f"local_matches_remote({self.alias}): "
-                f"remote={remote_ts}, local={local_ts}"
-            )
-            return remote_ts is not None and remote_ts == local_ts
         except Exception as e:
-            logger.warning(f"local_matches_remote check failed: {e}")
+            logger.warning(
+                f"local_matches_remote({self.alias}) local read failed: {e}"
+            )
             return False
+
+        logger.info(
+            f"local_matches_remote({self.alias}, probe={self.probe_table}): "
+            f"remote={remote_ts}, local={local_ts}"
+        )
+        return remote_ts == local_ts
 
     def _cleanup_empty_db_file(self):
         """Remove empty db file and libsql/WAL artifacts left by a failed sync."""

--- a/pages/components/db_refresh.py
+++ b/pages/components/db_refresh.py
@@ -12,6 +12,7 @@ import streamlit as st
 from config import DatabaseConfig
 from init_db import ensure_market_db_ready, init_db
 from logging_config import setup_logging
+from repositories import invalidate_build_cost_caches
 from state.market_state import refresh_market_caches
 from state.sync_state import update_wcmkt_state
 
@@ -76,14 +77,14 @@ def check_db(manual_override: bool = False):
     all of them regardless of which market is currently active.
     """
     from state.market_state import get_active_market
-    from settings_service import get_all_market_configs
+    from settings_service import get_all_market_configs, get_freshness_probe_aliases
 
     active_alias = get_active_market().database_alias
-    market_aliases = [cfg.database_alias for cfg in get_all_market_configs().values()]
-    # Shared (non-market) databases that also need staleness checks.
-    # Each must have a [freshness_probes] entry in settings.toml.
-    shared_aliases = ["build_cost"]
-    all_aliases = market_aliases + shared_aliases
+    market_aliases = {cfg.database_alias for cfg in get_all_market_configs().values()}
+    # Any alias with a freshness probe that isn't a market hub is a shared DB
+    # (e.g. build_cost, sde) that also needs periodic staleness checks.
+    shared_aliases = [a for a in get_freshness_probe_aliases() if a not in market_aliases]
+    all_aliases = list(market_aliases) + shared_aliases
 
     if manual_override:
         check_for_db_updates.clear()
@@ -140,10 +141,9 @@ def check_db(manual_override: bool = False):
         # Drop the freshness-check cache so the next run doesn't resync from
         # a stale "stale" verdict cached before the sync happened.
         check_for_db_updates.clear()
-        if any(a in market_aliases for a in synced_aliases):
+        if not market_aliases.isdisjoint(synced_aliases):
             refresh_market_caches()
         if "build_cost" in synced_aliases:
-            from repositories.build_cost_repo import invalidate_build_cost_caches
             invalidate_build_cost_caches()
         update_wcmkt_state()
         # Mark this run as having completed a check so the periodic guard

--- a/pages/components/db_refresh.py
+++ b/pages/components/db_refresh.py
@@ -79,7 +79,11 @@ def check_db(manual_override: bool = False):
     from settings_service import get_all_market_configs
 
     active_alias = get_active_market().database_alias
-    all_aliases = [cfg.database_alias for cfg in get_all_market_configs().values()]
+    market_aliases = [cfg.database_alias for cfg in get_all_market_configs().values()]
+    # Shared (non-market) databases that also need staleness checks.
+    # Each must have a [freshness_probes] entry in settings.toml.
+    shared_aliases = ["build_cost"]
+    all_aliases = market_aliases + shared_aliases
 
     if manual_override:
         check_for_db_updates.clear()
@@ -88,6 +92,7 @@ def check_db(manual_override: bool = False):
         logger.info("*" * 60)
 
     synced_any = False
+    synced_aliases: list[str] = []
     any_stale = False
     any_sync_failed = False
     local_only_mode = False
@@ -121,6 +126,7 @@ def check_db(manual_override: bool = False):
                 if db.local_matches_remote():
                     logger.info(f"{alias} synced and validated")
                     synced_any = True
+                    synced_aliases.append(alias)
                 else:
                     logger.warning(f"{alias} sync failed validation")
                     any_sync_failed = True
@@ -134,7 +140,11 @@ def check_db(manual_override: bool = False):
         # Drop the freshness-check cache so the next run doesn't resync from
         # a stale "stale" verdict cached before the sync happened.
         check_for_db_updates.clear()
-        refresh_market_caches()
+        if any(a in market_aliases for a in synced_aliases):
+            refresh_market_caches()
+        if "build_cost" in synced_aliases:
+            from repositories.build_cost_repo import invalidate_build_cost_caches
+            invalidate_build_cost_caches()
         update_wcmkt_state()
         # Mark this run as having completed a check so the periodic guard
         # in maybe_run_check() doesn't immediately re-fire after the rerun.

--- a/settings.toml
+++ b/settings.toml
@@ -101,6 +101,14 @@
     "sde" = "sdelite_turso"
     "build_cost" = "buildcost_turso"
 
+# Maps db alias → table_name value to probe in its `updatelog` table for
+# post-sync freshness validation. Aliases without an entry skip the probe
+# (sync is trusted as soon as libsql.connect.sync() returns).
+[freshness_probes]
+    "wcmktprod" = "marketstats"
+    "wcmktnorth" = "marketstats"
+    "build_cost" = "buildcost"
+
 [env_db_aliases]
     "prod" = "wcmktprod"
     "dev" = "wcmkttest"

--- a/settings_service.py
+++ b/settings_service.py
@@ -27,6 +27,16 @@ def _load_settings(settings_path: Path = Path("settings.toml")) -> dict:
         raise
 
 
+def get_freshness_probe_aliases() -> list[str]:
+    """Return database aliases configured for post-sync freshness probes.
+
+    Source of truth for "which DBs participate in periodic staleness
+    checking" — driven by ``[freshness_probes]`` in settings.toml.
+    """
+    settings = _load_settings()
+    return list(settings.get("freshness_probes", {}).keys())
+
+
 def get_all_market_configs() -> dict:
     """Return a dict of MarketConfig keyed by market key (e.g. 'primary').
 

--- a/state/sync_state.py
+++ b/state/sync_state.py
@@ -5,6 +5,7 @@ from time import perf_counter
 
 import streamlit as st
 
+from models import UpdateLog
 from state.session_state import ss_set
 from state.market_state import get_active_market
 logger = setup_logging(__name__)
@@ -43,7 +44,7 @@ def update_wcmkt_state(db_alias: str = None, skip_remote: bool = False) -> None:
 
     now = datetime.now(timezone.utc)
 
-    local_update = db.get_most_recent_update("marketstats", remote=False)
+    local_update = db.get_most_recent_update("marketstats", UpdateLog, remote=False)
     local_update_status['updated'] = local_update
     if local_update is not None:
         local_update_status['time_since'] = now - local_update
@@ -53,7 +54,7 @@ def update_wcmkt_state(db_alias: str = None, skip_remote: bool = False) -> None:
 
     if not skip_remote and db.has_remote_credentials:
         try:
-            remote_update = db.get_most_recent_update("marketstats", remote=True)
+            remote_update = db.get_most_recent_update("marketstats", UpdateLog, remote=True)
             remote_update_status['updated'] = remote_update
             if remote_update is not None:
                 remote_update_status['time_since'] = now - remote_update

--- a/ui/sync_display.py
+++ b/ui/sync_display.py
@@ -11,6 +11,7 @@ import streamlit as st
 
 from config import DatabaseConfig
 from logging_config import setup_logging
+from models import UpdateLog
 from state.sync_state import minutes_until_next_update
 from ui.i18n import translate_text
 
@@ -47,7 +48,7 @@ def display_sync_status(language_code: str = "en"):
         time_since = status.get("time_since")
         if update_time is None:
             try:
-                update_time = DatabaseConfig(active_alias).get_most_recent_update("marketstats", remote=False)
+                update_time = DatabaseConfig(active_alias).get_most_recent_update("marketstats", UpdateLog, remote=False)
                 status["updated"] = update_time
             except Exception as exc:
                 logger.error(f"Error fetching cached update time: {exc}")
@@ -56,7 +57,7 @@ def display_sync_status(language_code: str = "en"):
             status["time_since"] = time_since
     else:
         try:
-            update_time = DatabaseConfig(active_alias).get_most_recent_update("marketstats", remote=False)
+            update_time = DatabaseConfig(active_alias).get_most_recent_update("marketstats", UpdateLog, remote=False)
         except Exception as exc:
             logger.error(f"Error fetching update time: {exc}")
         if update_time is not None:


### PR DESCRIPTION
The wcmkts_new Streamlit app was previously unable to detect when buildcost.db had been updated by the backend — the periodic sync loop only checked market databases. This PR generalizes the frontend sync function to support a per-database freshness probe: each DB's updatelog table gets a row written after every backend update, and the frontend compares local vs remote AX(timestamp) for a configured probe key to determine whether the db needs to sync to update new data.