### PR TITLE
Improve Loading Performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,28 +343,57 @@ if __name__ == "__main__":
 
 **Best Practices:**
 - Access data through repository and service layers, not direct `DatabaseConfig`
-- Use context managers for database sessions
 - Implement proper error handling and logging
 - Use targeted cache invalidation after sync (e.g., `invalidate_market_caches()`), not global `st.cache_data.clear()`
 
-**Example:**
+#### Read Convention: raw SQL via `text()`, executed through `read_df()`
+
+This app is **read-only analytics**: its job is `SELECT … GROUP BY` feeding pandas
+DataFrames. We deliberately do **not** use the SQLAlchemy ORM for reads — the
+ORM's value (identity map, unit-of-work, lazy relationships, change tracking) is
+about object writes and graphs, none of which apply when the output is a
+DataFrame. The ORM models in `models.py` / `sdemodels.py` / `build_cost_models.py`
+exist for **schema definition/seeding** (`demo_data.py`), the **one write path**
+(`admin_repo.py`'s `sqlite_insert(Watchlist)`), and as living schema docs — not
+for queries. Don't grow ORM into reads.
+
+The convention for every read is:
+
+1. Express the query as raw SQL with `sqlalchemy.text(...)`.
+2. Use **named** params, and `bindparam("ids", expanding=True)` for `IN` clauses
+   (never string-interpolate values into SQL).
+3. Execute it through **`BaseRepository.read_df()`** — the single chokepoint that
+   provides malformed-DB recovery → sync-and-retry → remote fallback. A bare
+   `db.engine.connect()` + `pd.read_sql_query` gets **none** of that resilience,
+   so a corrupt local `.db` makes those queries throw "no such table" instead of
+   self-healing.
+
 ```python
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy import text, bindparam
 from config import DatabaseConfig
-from models import MarketStats
+from repositories.base import BaseRepository
 
-# Reading data via DatabaseConfig
-mkt_db = DatabaseConfig("wcmktprod")
-with Session(mkt_db.engine) as session:
-    stmt = select(MarketStats).where(MarketStats.type_id == 34)
-    results = session.execute(stmt).scalars().all()
+# CORRECT — raw SQL through read_df() (recovery + remote fallback included)
+repo = BaseRepository(DatabaseConfig("wcmktprod"))
+query = text(
+    "SELECT type_id, min_price FROM marketstats WHERE type_id IN :ids"
+).bindparams(bindparam("ids", expanding=True))
+df = repo.read_df(query, params={"ids": [34, 35]})
 
-# Or use repository cached methods (preferred)
+# Or, preferred at call sites, a cached repository method
 from repositories import get_market_repository
-repo = get_market_repository()
-df = repo.get_all_stats()  # Returns cached pandas DataFrame
+df = get_market_repository().get_all_stats()  # cached DataFrame
 ```
+
+```python
+# AVOID — bypasses read_df(), so no malformed-DB recovery / remote fallback
+with DatabaseConfig("wcmktprod").engine.connect() as conn:
+    df = pd.read_sql_query(query, conn, params={"ids": [34, 35]})
+```
+
+> **Known drift (future refactor):** many existing read sites still use the
+> bare-`engine.connect()` form. See `docs/read_df_consolidation.md` for the full
+> inventory and migration plan. New reads should follow the convention above.
 
 ### Performance Considerations
 

--- a/docs/read_df_consolidation.md
+++ b/docs/read_df_consolidation.md
@@ -1,0 +1,124 @@
+# Read Consolidation: route all DB reads through `BaseRepository.read_df()`
+
+**Status:** proposed (future refactoring project)
+**Owner:** TBD
+**Related convention:** see *Database Operations → Read Convention* in `CLAUDE.md`.
+
+## Motivation
+
+The app reads SQLite/libSQL three different ways today. Only one of them carries
+the resilience guarantees the architecture advertises:
+
+| Pattern | Recovery on malformed/corrupt DB? | Remote fallback? |
+|---|---|---|
+| `BaseRepository.read_df(text(...))` | ✅ sync-and-retry | ✅ falls back to `remote_engine` |
+| Bare `db.engine.connect()` + `pd.read_sql_query` | ❌ | ❌ |
+| SQLAlchemy ORM `select()` reads | n/a — **not used anywhere** | n/a |
+
+`read_df()` (`repositories/base.py`) is the intended single chokepoint:
+local read → on malformed error `db.sync()` + retry → if still failing, read from
+`db.remote_engine`. Every site that calls `engine.connect()` directly silently
+opts out of that, so a corrupt local `.db` makes those queries throw
+("no such table" / "database disk image is malformed") instead of self-healing —
+exactly the failure mode `read_df()` exists to prevent (and that `init_db.py` /
+cold-start notes in `CLAUDE.md` reference).
+
+This is a **consistency + resilience** refactor, not a behavior change. No query
+logic should change; only *how* each query is executed.
+
+## Decision (already ratified)
+
+- **Reads stay raw SQL** via `sqlalchemy.text(...)`. The ORM is *not* adopted for
+  reads — it earns its keep only for schema definition/seeding (`demo_data.py`),
+  the single write path (`admin_repo.py`), and as schema documentation.
+- **Every read flows through `read_df()`** so recovery + remote fallback are
+  uniform.
+- Params are **named**; `IN` clauses use `bindparam(name, expanding=True)`.
+
+## Scope: ~39 direct-`engine.connect()` read sites across 10 files
+
+Counts captured at the time of writing (`grep -c "engine.connect()"`):
+
+| File | Sites | Notes |
+|---|---:|---|
+| `repositories/market_repo.py` | 12 | mix of `wcmkt` and `sde` reads; `_get_watchlist_impl` already shows the correct `read_df()` form to copy |
+| `repositories/doctrine_repo.py` | 8 | |
+| `repositories/build_cost_repo.py` | 4 | `build_cost` alias |
+| `repositories/sde_repo.py` | 3 | `sde` alias; note `@st.cache_resource` (no TTL) on SDE reads |
+| `repositories/admin_repo.py` | 3 | **reads** here should move to `read_df`; the **write** path (`DELETE` + `sqlite_insert(Watchlist)`) stays on a direct transactional connection — `read_df` is read-only |
+| `repositories/market_orders_repo.py` | 2 | |
+| `services/type_resolution_service.py` | 3 | service-level DB access; consider pushing into a repo while here |
+| `services/price_service.py` | 2 | `DatabasePriceProvider` reads `jita_prices`; keep provider abstraction, just swap execution |
+| `services/import_helper_service.py` | 1 | |
+| `services/module_equivalents_service.py` | 1 | `_get_equivalent_type_ids` / equivalence-group cached helpers still use a passed-in `engine`; `_get_module_stocks` was already migrated to `read_df()` |
+
+> Regenerate the live list before starting:
+> ```bash
+> grep -rn "engine.connect()" repositories/ services/
+> ```
+
+## Migration recipe (per site)
+
+Before:
+```python
+db = DatabaseConfig(db_alias)
+query = text("SELECT ... WHERE type_id IN :ids").bindparams(
+    bindparam("ids", expanding=True)
+)
+with db.engine.connect() as conn:
+    df = pd.read_sql_query(query, conn, params={"ids": ids})
+```
+
+After:
+```python
+repo = BaseRepository(DatabaseConfig(db_alias), logger)
+query = text("SELECT ... WHERE type_id IN :ids").bindparams(
+    bindparam("ids", expanding=True)
+)
+df = repo.read_df(query, params={"ids": ids})
+```
+
+Notes:
+- `read_df()` accepts a `text()` clause (or a raw SQL string) plus `params`, and
+  takes `local=` / `fallback_remote_on_malformed=` kwargs if a site needs to opt
+  out of fallback.
+- Where a module already holds a `DatabaseConfig` (e.g. services with
+  `self._mkt_db`), build `BaseRepository(self._mkt_db, self._logger)` rather than
+  constructing a new `DatabaseConfig`.
+- Functions that currently wrap the read in `try/except` returning an empty
+  DataFrame can keep that outer guard; `read_df()` only adds recovery, it still
+  raises on non-malformed errors.
+
+## Explicit non-goals / carve-outs
+
+- **Writes** (`admin_repo.py` `DELETE`/`sqlite_insert`, `demo_data.py`
+  `create_all` + seeding) stay as-is — `read_df()` is read-only by design.
+- **`config.py` sync/integrity** internals (`libsql.connect`, `PRAGMA`
+  `integrity_check`) are infrastructure, not application reads — out of scope.
+- The cached `engine`-passing helpers in `module_equivalents_service.py` may need
+  a small signature change (pass `DatabaseConfig`/alias instead of a raw
+  `engine`) so they can build a `BaseRepository`; do this deliberately, not as a
+  blind swap.
+
+## Validation
+
+- `uv run pytest -q` — the suite mostly mocks repositories, so most sites change
+  without test churn. Sites that mock `engine.connect()` directly will need their
+  mocks updated to the `read_df()` boundary.
+- **Coverage gaps to close while here:** there is currently **no test file for
+  `ModuleEquivalentsService`** (`get_aggregated_stock`, `_get_module_stocks`,
+  equivalence-group aggregation are untested). Add one as part of this work —
+  the `_get_module_stocks` → `read_df()` migration done in the perf pass shipped
+  without direct coverage.
+- Manual smoke: rename/corrupt a local `.db` and confirm pages recover via sync /
+  remote fallback instead of surfacing "no such table".
+
+## Suggested sequencing
+
+1. `repositories/` first (highest density, best test coverage) — `market_repo.py`,
+   then `doctrine_repo.py`, then the smaller repos.
+2. `services/` that hit the DB directly — ideally push those reads down into the
+   appropriate repository while migrating, to retire service-level DB access.
+3. Add the `ModuleEquivalentsService` test file.
+4. Optional: a lightweight lint/CI guard (e.g. grep check) that fails on new
+   `engine.connect()` reads outside `base.py` / write paths, to prevent regression.

--- a/docs/read_df_consolidation.md
+++ b/docs/read_df_consolidation.md
@@ -35,22 +35,30 @@ logic should change; only *how* each query is executed.
   uniform.
 - Params are **named**; `IN` clauses use `bindparam(name, expanding=True)`.
 
-## Scope: ~39 direct-`engine.connect()` read sites across 10 files
+## Scope: 53 direct-`engine.connect()` local read sites across 10 files
 
-Counts captured at the time of writing (`grep -c "engine.connect()"`):
+Counts verified via `grep -c "engine.connect()"` minus `remote_engine.connect()`,
+excluding `repositories/base.py` (its 2 connects *are* the `read_df()` chokepoint —
+the source of truth, not a migration target):
 
-| File | Sites | Notes |
+| File | Local read sites | Notes |
 |---|---:|---|
-| `repositories/market_repo.py` | 12 | mix of `wcmkt` and `sde` reads; `_get_watchlist_impl` already shows the correct `read_df()` form to copy |
-| `repositories/doctrine_repo.py` | 8 | |
-| `repositories/build_cost_repo.py` | 4 | `build_cost` alias |
-| `repositories/sde_repo.py` | 3 | `sde` alias; note `@st.cache_resource` (no TTL) on SDE reads |
-| `repositories/admin_repo.py` | 3 | **reads** here should move to `read_df`; the **write** path (`DELETE` + `sqlite_insert(Watchlist)`) stays on a direct transactional connection — `read_df` is read-only |
-| `repositories/market_orders_repo.py` | 2 | |
-| `services/type_resolution_service.py` | 3 | service-level DB access; consider pushing into a repo while here |
+| `repositories/sde_repo.py` | 10 | `sde` alias; mostly `@st.cache_resource` (no TTL); one `remote_engine.connect()` already used as a manual fallback |
+| `repositories/market_repo.py` | 9 | mix of `wcmkt` and `sde` reads; `_get_watchlist_impl` / the snapshot+KPI impls already show the correct `read_df()` form to copy |
+| `services/low_stock_service.py` | 7 | service-level DB access; reads `wcmkt` + `sde` |
+| `repositories/doctrine_repo.py` | 6 | several methods already use `read_df()` — finish the stragglers |
+| `repositories/build_cost_repo.py` | 5 | `build_cost` alias |
+| `repositories/market_orders_repo.py` | 4 | |
+| `services/pricer_service.py` | 4 | `wcmkt` + `sde` reads |
+| `services/import_helper_service.py` | 3 | `wcmkt` + `sde` reads |
+| `services/module_equivalents_service.py` | 3 | cached equivalence-group helpers that take a passed-in `engine`; `_get_module_stocks` was already migrated to `read_df()` |
 | `services/price_service.py` | 2 | `DatabasePriceProvider` reads `jita_prices`; keep provider abstraction, just swap execution |
-| `services/import_helper_service.py` | 1 | |
-| `services/module_equivalents_service.py` | 1 | `_get_equivalent_type_ids` / equivalence-group cached helpers still use a passed-in `engine`; `_get_module_stocks` was already migrated to `read_df()` |
+
+> **Already compliant (no work):** `repositories/admin_repo.py` (all reads go
+> through `self._reader.read_df(...)`; its **writes** — `DELETE` +
+> `sqlite_insert(Watchlist)` — correctly stay on a direct transactional
+> connection, since `read_df` is read-only) and
+> `services/type_resolution_service.py` (no direct `engine.connect()`).
 
 > Regenerate the live list before starting:
 > ```bash

--- a/pages/components/dashboard_components.py
+++ b/pages/components/dashboard_components.py
@@ -54,9 +54,56 @@ def _get_eve_icon_url(type_id: int) -> str:
     return f"https://images.evetech.net/types/{int(type_id)}/icon?size=32"
 
 
-def _add_jita_prices(df: pd.DataFrame, price_service, type_ids: list[int]) -> pd.DataFrame:
-    """Add jita_sell_price, jita_buy_price, and pct_diff_vs_jita_sell columns to a DataFrame."""
+class JitaDataUnavailableError(RuntimeError):
+    """Raised when the backend jita_prices table has no data for requested items.
+
+    The dashboard renders curated, backend-priced item sets (minerals,
+    isotopes, doctrine ships/modules). A missing Jita price for these is not
+    a normal "unpriced item" case — it means the backend pricing pipeline is
+    broken or the jita_prices table is empty/stale. Per the data-integrity
+    rule, we fail loudly rather than render 0 / N/A, which would silently
+    misreport prices to the user.
+    """
+
+
+def _require_jita_prices(price_service, type_ids: list[int]) -> dict:
+    """Fetch Jita prices from the backend and assert the data is present.
+
+    Returns the ``{type_id: PriceResult}`` map. Raises if the backend returns
+    no usable price for ANY requested id — a wholesale outage of the
+    backend-populated jita_prices table (individual unpriced oddities still
+    pass through and surface as 0).
+
+    Raises:
+        JitaDataUnavailableError: when no requested item has a usable price.
+    """
     jita_price_map = price_service.get_jita_prices(type_ids).prices
+    requested = [int(t) for t in dict.fromkeys(type_ids)]
+    has_any_price = any(
+        (pr := jita_price_map.get(tid)) is not None
+        and getattr(pr, "success", False)
+        and getattr(pr, "sell_price", 0) > 0
+        for tid in requested
+    )
+    if requested and not has_any_price:
+        raise JitaDataUnavailableError(
+            f"No Jita prices available from the backend for any of "
+            f"{len(requested)} requested items. The jita_prices table may be "
+            f"empty or stale."
+        )
+    return jita_price_map
+
+
+def _add_jita_prices(df: pd.DataFrame, price_service, type_ids: list[int]) -> pd.DataFrame:
+    """Add jita_sell_price, jita_buy_price, and pct_diff_vs_jita_sell columns.
+
+    Raises:
+        JitaDataUnavailableError: if the backend jita_prices table returns no
+            usable price for any requested type_id. Jita data now comes solely
+            from the backend pipeline; an empty/stale table is surfaced loudly.
+    """
+    jita_price_map = _require_jita_prices(price_service, type_ids)
+
     df["jita_sell_price"] = df["type_id"].map(
         lambda tid: _get_price_result_value(jita_price_map.get(int(tid)), "sell_price")
     )
@@ -168,7 +215,16 @@ def render_comparison_table(
     if comparison_df.empty:
         return None
 
-    comparison_df = _add_jita_prices(comparison_df, price_service, type_ids)
+    try:
+        comparison_df = _add_jita_prices(comparison_df, price_service, type_ids)
+    except JitaDataUnavailableError as e:
+        logger.error("Jita data unavailable for comparison table: %s", e)
+        st.error(
+            "Jita price data is unavailable (backend pricing pipeline may be "
+            "down or the jita_prices table is empty/stale). Prices are hidden "
+            "rather than shown as zero."
+        )
+        return None
 
     comparison_df["order_volume"] = (
         pd.to_numeric(comparison_df["order_volume"], errors="coerce").fillna(0).round().astype(int)
@@ -396,7 +452,16 @@ def render_popular_modules_table(
     if snapshot.empty:
         return None, None
 
-    snapshot = _add_jita_prices(snapshot, price_service, type_ids)
+    try:
+        snapshot = _add_jita_prices(snapshot, price_service, type_ids)
+    except JitaDataUnavailableError as e:
+        logger.error("Jita data unavailable for popular modules table: %s", e)
+        st.error(
+            "Jita price data is unavailable (backend pricing pipeline may be "
+            "down or the jita_prices table is empty/stale). Prices are hidden "
+            "rather than shown as zero."
+        )
+        return None, None
     snapshot["order_volume"] = (
         pd.to_numeric(snapshot["order_volume"], errors="coerce").fillna(0).round().astype(int)
     )
@@ -522,14 +587,15 @@ def _apply_equivalents_to_fits(fits_df: pd.DataFrame) -> pd.DataFrame:
     fits_df = fits_df.copy()
     aggregated_stocks = equiv_service.get_aggregated_stock(list(modules_to_update))
 
-    for type_id, total_stock in aggregated_stocks.items():
-        mask = fits_df["type_id"] == type_id
-        for idx in fits_df.loc[mask].index:
-            fit_qty = fits_df.at[idx, "fit_qty"]
-            if fit_qty > 0:
-                fits_df.at[idx, "fits_on_mkt"] = total_stock // fit_qty
-            else:
-                fits_df.at[idx, "fits_on_mkt"] = total_stock
+    # Vectorized update: rows whose type_id has an aggregated equivalent stock
+    # get fits_on_mkt = total_stock // fit_qty (or total_stock when fit_qty<=0).
+    mask = fits_df["type_id"].isin(aggregated_stocks)
+    if mask.any():
+        total_stock = fits_df.loc[mask, "type_id"].map(aggregated_stocks).astype("int64")
+        fit_qty = pd.to_numeric(fits_df.loc[mask, "fit_qty"], errors="coerce").fillna(0).astype("int64")
+        fits_df.loc[mask, "fits_on_mkt"] = total_stock.where(
+            fit_qty <= 0, total_stock // fit_qty.where(fit_qty > 0, 1)
+        )
 
     return fits_df
 
@@ -583,8 +649,18 @@ def render_doctrine_ships_table(
     # Local prices via snapshot
     snapshot = market_service.get_current_market_snapshot(ship_type_ids)
 
-    # Jita prices — batch fetch
-    jita_map = price_service.get_jita_prices(ship_type_ids).prices
+    # Jita prices — batch fetch from the backend jita_prices table.
+    # Fail loudly if the backend has no data for any doctrine ship.
+    try:
+        jita_map = _require_jita_prices(price_service, ship_type_ids)
+    except JitaDataUnavailableError as e:
+        logger.error("Jita data unavailable for doctrine ships table: %s", e)
+        st.error(
+            "Jita price data is unavailable (backend pricing pipeline may be "
+            "down or the jita_prices table is empty/stale). Prices are hidden "
+            "rather than shown as zero."
+        )
+        return None, None
 
     # Build result DataFrame — one row per fit_id
     rows = []

--- a/pages/components/dashboard_components.py
+++ b/pages/components/dashboard_components.py
@@ -54,28 +54,28 @@ def _get_eve_icon_url(type_id: int) -> str:
     return f"https://images.evetech.net/types/{int(type_id)}/icon?size=32"
 
 
-class JitaDataUnavailableError(RuntimeError):
-    """Raised when the backend jita_prices table has no data for requested items.
-
-    The dashboard renders curated, backend-priced item sets (minerals,
-    isotopes, doctrine ships/modules). A missing Jita price for these is not
-    a normal "unpriced item" case — it means the backend pricing pipeline is
-    broken or the jita_prices table is empty/stale. Per the data-integrity
-    rule, we fail loudly rather than render 0 / N/A, which would silently
-    misreport prices to the user.
-    """
+_JITA_UNAVAILABLE_MESSAGE = (
+    "Jita price data is unavailable — the backend pricing pipeline may be down "
+    "or the jita_prices table is empty/stale. Prices are hidden rather than "
+    "shown as zero."
+)
 
 
-def _require_jita_prices(price_service, type_ids: list[int]) -> dict:
-    """Fetch Jita prices from the backend and assert the data is present.
+def _require_jita_prices(price_service, type_ids: list[int]) -> dict | None:
+    """Fetch Jita prices from the backend, surfacing a wholesale outage to the UI.
 
-    Returns the ``{type_id: PriceResult}`` map. Raises if the backend returns
-    no usable price for ANY requested id — a wholesale outage of the
-    backend-populated jita_prices table (individual unpriced oddities still
-    pass through and surface as 0).
+    The dashboard renders curated, backend-priced item sets (minerals, isotopes,
+    doctrine ships/modules). If the backend returns no usable price for ANY
+    requested id, the jita_prices table is empty/stale or the pricing pipeline
+    is broken — not a normal "unpriced item" case. Per the data-integrity rule
+    we refuse to render 0 / N/A (which would silently misreport prices): we log
+    the failure and show ``st.error`` to the user, returning ``None`` so the
+    caller can skip the table gracefully. Individual unpriced oddities still
+    pass through and surface as 0.
 
-    Raises:
-        JitaDataUnavailableError: when no requested item has a usable price.
+    Returns:
+        The ``{type_id: PriceResult}`` map, or ``None`` when no requested item
+        has a usable Jita price (after logging and showing ``st.error``).
     """
     jita_price_map = price_service.get_jita_prices(type_ids).prices
     requested = [int(t) for t in dict.fromkeys(type_ids)]
@@ -86,24 +86,22 @@ def _require_jita_prices(price_service, type_ids: list[int]) -> dict:
         for tid in requested
     )
     if requested and not has_any_price:
-        raise JitaDataUnavailableError(
-            f"No Jita prices available from the backend for any of "
-            f"{len(requested)} requested items. The jita_prices table may be "
-            f"empty or stale."
+        logger.error(
+            "No Jita prices available from the backend for any of %d requested "
+            "items; jita_prices table may be empty or stale.",
+            len(requested),
         )
+        st.error(_JITA_UNAVAILABLE_MESSAGE)
+        return None
     return jita_price_map
 
 
-def _add_jita_prices(df: pd.DataFrame, price_service, type_ids: list[int]) -> pd.DataFrame:
+def _add_jita_prices(df: pd.DataFrame, jita_price_map: dict) -> pd.DataFrame:
     """Add jita_sell_price, jita_buy_price, and pct_diff_vs_jita_sell columns.
 
-    Raises:
-        JitaDataUnavailableError: if the backend jita_prices table returns no
-            usable price for any requested type_id. Jita data now comes solely
-            from the backend pipeline; an empty/stale table is surfaced loudly.
+    Expects an already-fetched/validated ``{type_id: PriceResult}`` map (see
+    ``_require_jita_prices``); this function only applies the price columns.
     """
-    jita_price_map = _require_jita_prices(price_service, type_ids)
-
     df["jita_sell_price"] = df["type_id"].map(
         lambda tid: _get_price_result_value(jita_price_map.get(int(tid)), "sell_price")
     )
@@ -215,16 +213,10 @@ def render_comparison_table(
     if comparison_df.empty:
         return None
 
-    try:
-        comparison_df = _add_jita_prices(comparison_df, price_service, type_ids)
-    except JitaDataUnavailableError as e:
-        logger.error("Jita data unavailable for comparison table: %s", e)
-        st.error(
-            "Jita price data is unavailable (backend pricing pipeline may be "
-            "down or the jita_prices table is empty/stale). Prices are hidden "
-            "rather than shown as zero."
-        )
+    jita_price_map = _require_jita_prices(price_service, type_ids)
+    if jita_price_map is None:
         return None
+    comparison_df = _add_jita_prices(comparison_df, jita_price_map)
 
     comparison_df["order_volume"] = (
         pd.to_numeric(comparison_df["order_volume"], errors="coerce").fillna(0).round().astype(int)
@@ -452,16 +444,10 @@ def render_popular_modules_table(
     if snapshot.empty:
         return None, None
 
-    try:
-        snapshot = _add_jita_prices(snapshot, price_service, type_ids)
-    except JitaDataUnavailableError as e:
-        logger.error("Jita data unavailable for popular modules table: %s", e)
-        st.error(
-            "Jita price data is unavailable (backend pricing pipeline may be "
-            "down or the jita_prices table is empty/stale). Prices are hidden "
-            "rather than shown as zero."
-        )
+    jita_price_map = _require_jita_prices(price_service, type_ids)
+    if jita_price_map is None:
         return None, None
+    snapshot = _add_jita_prices(snapshot, jita_price_map)
     snapshot["order_volume"] = (
         pd.to_numeric(snapshot["order_volume"], errors="coerce").fillna(0).round().astype(int)
     )
@@ -650,16 +636,9 @@ def render_doctrine_ships_table(
     snapshot = market_service.get_current_market_snapshot(ship_type_ids)
 
     # Jita prices — batch fetch from the backend jita_prices table.
-    # Fail loudly if the backend has no data for any doctrine ship.
-    try:
-        jita_map = _require_jita_prices(price_service, ship_type_ids)
-    except JitaDataUnavailableError as e:
-        logger.error("Jita data unavailable for doctrine ships table: %s", e)
-        st.error(
-            "Jita price data is unavailable (backend pricing pipeline may be "
-            "down or the jita_prices table is empty/stale). Prices are hidden "
-            "rather than shown as zero."
-        )
+    # Surfaces st.error + logs and bails if the backend has no data at all.
+    jita_map = _require_jita_prices(price_service, ship_type_ids)
+    if jita_map is None:
         return None, None
 
     # Build result DataFrame — one row per fit_id

--- a/pages/components/dashboard_components.py
+++ b/pages/components/dashboard_components.py
@@ -49,6 +49,21 @@ def _get_price_result_value(price_result, field_name: str) -> float:
         return 0.0
 
 
+def _jita_price_or_na(price_result, field_name: str) -> float:
+    """Return a Jita price field, or NaN when there is no usable Jita price.
+
+    A missing (``None``) or failed/backfilled (``success`` is False) result
+    yields NaN so the cell renders blank ("—") rather than a misleading 0 — a
+    missing Jita price does not mean the item is free at Jita (data-integrity
+    rule). Unlike ``_get_price_result_value`` (which returns 0.0 for absent
+    prices), this is used for the dashboard comparison columns, where a 0 would
+    compute a nonsense "% vs Jita".
+    """
+    if price_result is None or not getattr(price_result, "success", False):
+        return float("nan")
+    return _get_price_result_value(price_result, field_name)
+
+
 def _get_eve_icon_url(type_id: int) -> str:
     """Return the EVE icon URL for an item type."""
     return f"https://images.evetech.net/types/{int(type_id)}/icon?size=32"
@@ -68,10 +83,18 @@ def _require_jita_prices(price_service, type_ids: list[int]) -> dict | None:
     doctrine ships/modules). If the backend returns no usable price for ANY
     requested id, the jita_prices table is empty/stale or the pricing pipeline
     is broken — not a normal "unpriced item" case. Per the data-integrity rule
-    we refuse to render 0 / N/A (which would silently misreport prices): we log
-    the failure and show ``st.error`` to the user, returning ``None`` so the
-    caller can skip the table gracefully. Individual unpriced oddities still
-    pass through and surface as 0.
+    we refuse to render a table of fabricated zeros: we log the failure and show
+    ``st.error``, returning ``None`` so the caller can skip the table gracefully.
+    Individual unpriced items still pass through and render blank ("—"), never 0
+    (see ``_add_jita_prices`` / ``_jita_price_or_na``).
+
+    This loud, all-or-nothing guard lives ONLY on the dashboard on purpose: the
+    dashboard is the landing page, so a total outage is surfaced to every user
+    on normal navigation. The other Jita-consuming pages (Pricer, Builder
+    Helper, Import Helper, Doctrine) do not repeat the guard — they degrade
+    per-item to blank rather than 0, which is correct for a partial outage. The
+    only way to miss this alert is a direct deep-link straight to one of those
+    pages during a full outage — a negligible edge case.
 
     Returns:
         The ``{type_id: PriceResult}`` map, or ``None`` when no requested item
@@ -103,12 +126,14 @@ def _add_jita_prices(df: pd.DataFrame, jita_price_map: dict) -> pd.DataFrame:
     ``_require_jita_prices``); this function only applies the price columns.
     """
     df["jita_sell_price"] = df["type_id"].map(
-        lambda tid: _get_price_result_value(jita_price_map.get(int(tid)), "sell_price")
+        lambda tid: _jita_price_or_na(jita_price_map.get(int(tid)), "sell_price")
     )
     df["jita_buy_price"] = df["type_id"].map(
-        lambda tid: _get_price_result_value(jita_price_map.get(int(tid)), "buy_price")
+        lambda tid: _jita_price_or_na(jita_price_map.get(int(tid)), "buy_price")
     )
-    df["pct_diff_vs_jita_sell"] = 0.0
+    # NaN (not 0) where there is no usable Jita sell price — a missing price is
+    # not a 0% difference. Only rows with a real Jita sell get a computed value.
+    df["pct_diff_vs_jita_sell"] = float("nan")
     has_jita_sell = df["jita_sell_price"] > 0
     df.loc[has_jita_sell, "pct_diff_vs_jita_sell"] = (
         (
@@ -120,10 +145,18 @@ def _add_jita_prices(df: pd.DataFrame, jita_price_map: dict) -> pd.DataFrame:
     return df
 
 
-def _coerce_numeric(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
-    """Coerce columns to numeric, filling NaN with 0."""
+def _coerce_numeric(
+    df: pd.DataFrame, columns: list[str], fill_value: float | None = 0.0
+) -> pd.DataFrame:
+    """Coerce columns to numeric, filling NaN with ``fill_value``.
+
+    Pass ``fill_value=None`` to preserve NaN — used for Jita price columns,
+    where a fabricated 0 would misreport "no Jita data" as "free at Jita"
+    (data-integrity rule). NaN renders as a blank cell ("—") instead.
+    """
     for col in columns:
-        df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0.0)
+        series = pd.to_numeric(df[col], errors="coerce")
+        df[col] = series if fill_value is None else series.fillna(fill_value)
     return df
 
 
@@ -179,6 +212,8 @@ def _jita_diff_cell_style(diff_value: float) -> str:
         value = float(diff_value)
     except (TypeError, ValueError):
         return ""
+    if pd.isna(value):
+        return ""
     if value > 5:
         return "color: #66bb6a"
     if value < 0:
@@ -228,10 +263,13 @@ def render_comparison_table(
         comparison_df["type_id"].astype(str)
     )
     comparison_df["image_url"] = comparison_df["type_id"].map(_get_eve_icon_url)
-    comparison_df = _coerce_numeric(comparison_df, [
-        "current_sell_price", "order_volume",
-        "jita_sell_price", "jita_buy_price", "pct_diff_vs_jita_sell",
-    ])
+    comparison_df = _coerce_numeric(comparison_df, ["current_sell_price", "order_volume"])
+    # Jita columns keep NaN — a missing Jita price renders blank, never 0.
+    comparison_df = _coerce_numeric(
+        comparison_df,
+        ["jita_sell_price", "jita_buy_price", "pct_diff_vs_jita_sell"],
+        fill_value=None,
+    )
 
     display_cols = [
         "image_url", "type_name", "current_sell_price", "order_volume",
@@ -461,10 +499,13 @@ def render_popular_modules_table(
     snapshot = apply_localized_type_names(snapshot, sde_repo, language_code, logger)
     snapshot["type_name"] = snapshot["type_name"].fillna(snapshot["type_id"].astype(str))
     snapshot["image_url"] = snapshot["type_id"].map(_get_eve_icon_url)
-    snapshot = _coerce_numeric(snapshot, [
-        "current_sell_price", "order_volume",
-        "jita_sell_price", "jita_buy_price", "pct_diff_vs_jita_sell",
-    ])
+    snapshot = _coerce_numeric(snapshot, ["current_sell_price", "order_volume"])
+    # Jita columns keep NaN — a missing Jita price renders blank, never 0.
+    snapshot = _coerce_numeric(
+        snapshot,
+        ["jita_sell_price", "jita_buy_price", "pct_diff_vs_jita_sell"],
+        fill_value=None,
+    )
 
     # Sort alphabetically by item name
     snapshot = snapshot.sort_values("type_name", key=lambda s: s.str.lower())
@@ -666,7 +707,7 @@ def render_doctrine_ships_table(
         stock = int(hull.get("total_stock", 0) or 0)
         fits_on_mkt = int(bottleneck_fits.get(fid, 0))
         target = int(targets_map[fid])
-        jita_sell = _get_price_result_value(jita_map.get(sid), "sell_price")
+        jita_sell = _jita_price_or_na(jita_map.get(sid), "sell_price")
         status = StockStatus.from_stock_and_target(fits_on_mkt, target)
         status_icons = {
             StockStatus.CRITICAL: "🔴",

--- a/repositories/market_repo.py
+++ b/repositories/market_repo.py
@@ -189,6 +189,73 @@ def _get_local_price_impl(type_id: int, db_alias: str = "wcmkt") -> Optional[flo
         return None
 
 
+def _get_sell_order_summary_impl(type_ids: list[int], db_alias: str = "wcmkt") -> pd.DataFrame:
+    """Aggregate sell orders (min price, summed volume) for specific type_ids.
+
+    Pushes the is_buy_order filter and per-type aggregation into SQL so the
+    full marketorders table is never loaded into pandas just to be filtered.
+    """
+    cols = ["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
+    if not type_ids:
+        return pd.DataFrame(columns=cols)
+    db = DatabaseConfig(db_alias)
+    query = text(
+        """
+        SELECT type_id,
+               MIN(type_name) AS order_type_name,
+               MIN(price) AS sell_order_price,
+               COALESCE(SUM(volume_remain), 0) AS sell_order_volume
+        FROM marketorders
+        WHERE is_buy_order = 0 AND type_id IN :type_ids
+        GROUP BY type_id
+        """
+    ).bindparams(bindparam("type_ids", expanding=True))
+    with db.engine.connect() as conn:
+        return pd.read_sql_query(
+            query, conn, params={"type_ids": [int(tid) for tid in type_ids]}
+        )
+
+
+def _get_stats_for_type_ids_impl(type_ids: list[int], db_alias: str = "wcmkt") -> pd.DataFrame:
+    """Fetch marketstats rows for specific type_ids (filtered in SQL)."""
+    cols = ["type_id", "type_name", "min_price", "total_volume_remain"]
+    if not type_ids:
+        return pd.DataFrame(columns=cols)
+    db = DatabaseConfig(db_alias)
+    query = text(
+        """
+        SELECT type_id, type_name, min_price, total_volume_remain
+        FROM marketstats
+        WHERE type_id IN :type_ids
+        """
+    ).bindparams(bindparam("type_ids", expanding=True))
+    with db.engine.connect() as conn:
+        return pd.read_sql_query(
+            query, conn, params={"type_ids": [int(tid) for tid in type_ids]}
+        )
+
+
+def _get_order_counts_impl(db_alias: str = "wcmkt") -> dict:
+    """Count active sell/buy orders via a SQL GROUP BY (no full-table load)."""
+    db = DatabaseConfig(db_alias)
+    query = text(
+        "SELECT is_buy_order, COUNT(*) AS n FROM marketorders GROUP BY is_buy_order"
+    )
+    try:
+        with db.engine.connect() as conn:
+            df = pd.read_sql_query(query, conn)
+    except Exception as e:
+        logger.error(f"Failed to fetch order counts: {e}")
+        return {"active_sell_orders": 0, "active_buy_orders": 0}
+    if df.empty:
+        return {"active_sell_orders": 0, "active_buy_orders": 0}
+    counts = df.set_index("is_buy_order")["n"].to_dict()
+    return {
+        "active_sell_orders": int(counts.get(0, 0)),
+        "active_buy_orders": int(counts.get(1, 0)),
+    }
+
+
 def _get_sde_info_impl(type_ids: list) -> pd.DataFrame:
     """Fetch SDE info (name, group, category) for given type_ids."""
     if not type_ids:
@@ -276,6 +343,21 @@ def _get_local_price_cached(type_id: int, db_alias: str = "wcmkt") -> Optional[f
     return _get_local_price_impl(type_id, db_alias)
 
 
+@st.cache_data(ttl=1800)
+def _get_sell_order_summary_cached(type_ids: tuple, db_alias: str = "wcmkt") -> pd.DataFrame:
+    return _get_sell_order_summary_impl(list(type_ids), db_alias)
+
+
+@st.cache_data(ttl=600)
+def _get_stats_for_type_ids_cached(type_ids: tuple, db_alias: str = "wcmkt") -> pd.DataFrame:
+    return _get_stats_for_type_ids_impl(list(type_ids), db_alias)
+
+
+@st.cache_data(ttl=1800)
+def _get_order_counts_cached(db_alias: str = "wcmkt") -> dict:
+    return _get_order_counts_impl(db_alias)
+
+
 @st.cache_resource
 def _get_sde_info_cached(type_ids: tuple) -> pd.DataFrame:
     return _get_sde_info_impl(list(type_ids))
@@ -308,6 +390,9 @@ def invalidate_market_caches():
     _get_market_type_ids_cached.clear()
     _get_local_price_cached.clear()
     _get_watchlist_cached.clear()
+    _get_sell_order_summary_cached.clear()
+    _get_stats_for_type_ids_cached.clear()
+    _get_order_counts_cached.clear()
     logger.info("Market caches invalidated")
 
 
@@ -427,6 +512,22 @@ class MarketRepository(BaseRepository):
     def get_market_type_ids(self) -> list:
         """Get all type_ids on market + watchlist (cached, TTL=1800s)."""
         return _get_market_type_ids_cached(self.db.alias)
+
+    def get_sell_order_summary(self, type_ids: list[int]) -> pd.DataFrame:
+        """Get aggregated sell-order price/volume for type_ids (cached, TTL=1800s).
+
+        Filtering and aggregation happen in SQL, so the full marketorders
+        table is never loaded into memory for a fixed-item snapshot.
+        """
+        return _get_sell_order_summary_cached(tuple(type_ids), self.db.alias)
+
+    def get_stats_for_type_ids(self, type_ids: list[int]) -> pd.DataFrame:
+        """Get marketstats rows for specific type_ids (cached, TTL=600s)."""
+        return _get_stats_for_type_ids_cached(tuple(type_ids), self.db.alias)
+
+    def get_order_counts(self) -> dict:
+        """Get active sell/buy order counts via SQL aggregation (cached, TTL=1800s)."""
+        return _get_order_counts_cached(self.db.alias)
 
     def get_sde_info(self, type_ids: list = None) -> pd.DataFrame:
         """Get SDE info for type_ids. If None, uses market type_ids."""

--- a/repositories/market_repo.py
+++ b/repositories/market_repo.py
@@ -198,7 +198,7 @@ def _get_sell_order_summary_impl(type_ids: list[int], db_alias: str = "wcmkt") -
     cols = ["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
     if not type_ids:
         return pd.DataFrame(columns=cols)
-    db = DatabaseConfig(db_alias)
+    repo = BaseRepository(DatabaseConfig(db_alias), logger)
     query = text(
         """
         SELECT type_id,
@@ -210,10 +210,7 @@ def _get_sell_order_summary_impl(type_ids: list[int], db_alias: str = "wcmkt") -
         GROUP BY type_id
         """
     ).bindparams(bindparam("type_ids", expanding=True))
-    with db.engine.connect() as conn:
-        return pd.read_sql_query(
-            query, conn, params={"type_ids": [int(tid) for tid in type_ids]}
-        )
+    return repo.read_df(query, params={"type_ids": [int(tid) for tid in type_ids]})
 
 
 def _get_stats_for_type_ids_impl(type_ids: list[int], db_alias: str = "wcmkt") -> pd.DataFrame:
@@ -221,7 +218,7 @@ def _get_stats_for_type_ids_impl(type_ids: list[int], db_alias: str = "wcmkt") -
     cols = ["type_id", "type_name", "min_price", "total_volume_remain"]
     if not type_ids:
         return pd.DataFrame(columns=cols)
-    db = DatabaseConfig(db_alias)
+    repo = BaseRepository(DatabaseConfig(db_alias), logger)
     query = text(
         """
         SELECT type_id, type_name, min_price, total_volume_remain
@@ -229,21 +226,17 @@ def _get_stats_for_type_ids_impl(type_ids: list[int], db_alias: str = "wcmkt") -
         WHERE type_id IN :type_ids
         """
     ).bindparams(bindparam("type_ids", expanding=True))
-    with db.engine.connect() as conn:
-        return pd.read_sql_query(
-            query, conn, params={"type_ids": [int(tid) for tid in type_ids]}
-        )
+    return repo.read_df(query, params={"type_ids": [int(tid) for tid in type_ids]})
 
 
 def _get_order_counts_impl(db_alias: str = "wcmkt") -> dict:
     """Count active sell/buy orders via a SQL GROUP BY (no full-table load)."""
-    db = DatabaseConfig(db_alias)
+    repo = BaseRepository(DatabaseConfig(db_alias), logger)
     query = text(
         "SELECT is_buy_order, COUNT(*) AS n FROM marketorders GROUP BY is_buy_order"
     )
     try:
-        with db.engine.connect() as conn:
-            df = pd.read_sql_query(query, conn)
+        df = repo.read_df(query)
     except Exception as e:
         logger.error(f"Failed to fetch order counts: {e}")
         return {"active_sell_orders": 0, "active_buy_orders": 0}

--- a/repositories/market_repo.py
+++ b/repositories/market_repo.py
@@ -230,16 +230,19 @@ def _get_stats_for_type_ids_impl(type_ids: list[int], db_alias: str = "wcmkt") -
 
 
 def _get_order_counts_impl(db_alias: str = "wcmkt") -> dict:
-    """Count active sell/buy orders via a SQL GROUP BY (no full-table load)."""
+    """Count active sell/buy orders via a SQL GROUP BY (no full-table load).
+
+    No try/except here: read_df() already attempts sync + remote-fallback
+    recovery and only raises on genuinely unrecoverable failures. Swallowing
+    that to {0, 0} would misreport a broken read as a real empty market
+    (data-integrity rule) — let it propagate so the caller can surface it. A
+    legitimately empty result (no rows) is still a true zero, handled below.
+    """
     repo = BaseRepository(DatabaseConfig(db_alias), logger)
     query = text(
         "SELECT is_buy_order, COUNT(*) AS n FROM marketorders GROUP BY is_buy_order"
     )
-    try:
-        df = repo.read_df(query)
-    except Exception as e:
-        logger.error(f"Failed to fetch order counts: {e}")
-        return {"active_sell_orders": 0, "active_buy_orders": 0}
+    df = repo.read_df(query)
     if df.empty:
         return {"active_sell_orders": 0, "active_buy_orders": 0}
     counts = df.set_index("is_buy_order")["n"].to_dict()

--- a/services/import_helper_service.py
+++ b/services/import_helper_service.py
@@ -78,19 +78,32 @@ PACKAGED_SHIP_VOLUMES_M3: dict[str, float] = {
 
 
 def _get_jita_sell_price(jita_prices: dict, type_id) -> float:
-    """Safely extract Jita sell price from a provider result map."""
+    """Jita sell price from a provider result map, or NaN when unavailable.
+
+    A missing or failed/backfilled result (``None`` or ``success`` False)
+    yields NaN, not 0: a 0 would make an unpriced item look free at Jita and
+    fabricate a huge import margin (data-integrity rule). NaN profit rows are
+    dropped by the profitable-only filter and sink in the sort order.
+    """
     if pd.isna(type_id):
-        return 0.0
+        return float("nan")
     result: Optional[PriceResult] = jita_prices.get(int(type_id))
-    return result.sell_price if result else 0.0
+    if result is None or not getattr(result, "success", False):
+        return float("nan")
+    return result.sell_price
 
 
 def _get_jita_buy_price(jita_prices: dict, type_id) -> float:
-    """Safely extract Jita buy price from a provider result map."""
+    """Jita buy price from a provider result map, or NaN when unavailable.
+
+    See ``_get_jita_sell_price`` — missing/failed prices are NaN, never 0.
+    """
     if pd.isna(type_id):
-        return 0.0
+        return float("nan")
     result: Optional[PriceResult] = jita_prices.get(int(type_id))
-    return result.buy_price if result else 0.0
+    if result is None or not getattr(result, "success", False):
+        return float("nan")
+    return result.buy_price
 
 
 def _apply_packaged_ship_volumes(

--- a/services/market_service.py
+++ b/services/market_service.py
@@ -124,13 +124,7 @@ class MarketService:
         # Fetch only the requested rows — filtering and (for orders) the sell
         # aggregation happen in SQL via the repository, so the full
         # marketstats / marketorders tables are never loaded into pandas.
-        if hasattr(self._repo, "get_stats_for_type_ids"):
-            stats_df = self._repo.get_stats_for_type_ids(requested_ids)
-        else:
-            # Fallback for repositories without the targeted query (e.g. test mocks)
-            stats_df = self._repo.get_all_stats()
-            if stats_df is not None and not stats_df.empty:
-                stats_df = stats_df[stats_df["type_id"].isin(requested_ids)]
+        stats_df = self._repo.get_stats_for_type_ids(requested_ids)
         if stats_df is None or stats_df.empty:
             stats_df = pd.DataFrame(
                 columns=["type_id", "type_name", "min_price", "total_volume_remain"]
@@ -147,24 +141,7 @@ class MarketService:
                 errors="coerce",
             )
 
-        if hasattr(self._repo, "get_sell_order_summary"):
-            sell_summary = self._repo.get_sell_order_summary(requested_ids)
-        else:
-            # Fallback path for repositories without the targeted query.
-            orders_df = self._repo.get_all_orders()
-            if orders_df is None or orders_df.empty:
-                sell_summary = pd.DataFrame(
-                    columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
-                )
-            else:
-                sell_orders = orders_df[
-                    (orders_df["is_buy_order"] == 0) & (orders_df["type_id"].isin(requested_ids))
-                ].copy()
-                sell_summary = sell_orders.groupby("type_id", as_index=False).agg(
-                    order_type_name=("type_name", "first"),
-                    sell_order_price=("price", "min"),
-                    sell_order_volume=("volume_remain", "sum"),
-                )
+        sell_summary = self._repo.get_sell_order_summary(requested_ids)
         if sell_summary is None or sell_summary.empty:
             sell_summary = pd.DataFrame(
                 columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
@@ -217,17 +194,9 @@ class MarketService:
 
         # Order counts come from a SQL GROUP BY rather than loading the full
         # marketorders table just to count rows by is_buy_order.
-        if hasattr(self._repo, "get_order_counts"):
-            counts = self._repo.get_order_counts()
-            active_sell_orders = int(counts.get("active_sell_orders", 0))
-            active_buy_orders = int(counts.get("active_buy_orders", 0))
-        else:
-            orders_df = self._repo.get_all_orders()
-            active_sell_orders = 0
-            active_buy_orders = 0
-            if orders_df is not None and not orders_df.empty:
-                active_sell_orders = int((orders_df["is_buy_order"] == 0).sum())
-                active_buy_orders = int((orders_df["is_buy_order"] == 1).sum())
+        counts = self._repo.get_order_counts()
+        active_sell_orders = int(counts.get("active_sell_orders", 0))
+        active_buy_orders = int(counts.get("active_buy_orders", 0))
 
         last_updated = self._repo.get_update_time()
 

--- a/services/market_service.py
+++ b/services/market_service.py
@@ -121,15 +121,23 @@ class MarketService:
         requested_ids = [int(type_id) for type_id in dict.fromkeys(type_ids)]
         base_df = pd.DataFrame({"type_id": requested_ids})
 
-        stats_df = self._repo.get_all_stats()
+        # Fetch only the requested rows — filtering and (for orders) the sell
+        # aggregation happen in SQL via the repository, so the full
+        # marketstats / marketorders tables are never loaded into pandas.
+        if hasattr(self._repo, "get_stats_for_type_ids"):
+            stats_df = self._repo.get_stats_for_type_ids(requested_ids)
+        else:
+            # Fallback for repositories without the targeted query (e.g. test mocks)
+            stats_df = self._repo.get_all_stats()
+            if stats_df is not None and not stats_df.empty:
+                stats_df = stats_df[stats_df["type_id"].isin(requested_ids)]
         if stats_df is None or stats_df.empty:
             stats_df = pd.DataFrame(
                 columns=["type_id", "type_name", "min_price", "total_volume_remain"]
             )
         else:
             stats_df = (
-                stats_df[stats_df["type_id"].isin(requested_ids)]
-                [["type_id", "type_name", "min_price", "total_volume_remain"]]
+                stats_df[["type_id", "type_name", "min_price", "total_volume_remain"]]
                 .drop_duplicates(subset=["type_id"])
                 .copy()
             )
@@ -139,30 +147,36 @@ class MarketService:
                 errors="coerce",
             )
 
-        orders_df = self._repo.get_all_orders()
-        if orders_df is None or orders_df.empty:
-            sell_summary = pd.DataFrame(
-                columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
-            )
+        if hasattr(self._repo, "get_sell_order_summary"):
+            sell_summary = self._repo.get_sell_order_summary(requested_ids)
         else:
-            sell_orders = orders_df[
-                (orders_df["is_buy_order"] == 0) & (orders_df["type_id"].isin(requested_ids))
-            ].copy()
-            if sell_orders.empty:
+            # Fallback path for repositories without the targeted query.
+            orders_df = self._repo.get_all_orders()
+            if orders_df is None or orders_df.empty:
                 sell_summary = pd.DataFrame(
                     columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
                 )
             else:
-                sell_orders["price"] = pd.to_numeric(sell_orders["price"], errors="coerce")
-                sell_orders["volume_remain"] = pd.to_numeric(
-                    sell_orders["volume_remain"],
-                    errors="coerce",
-                )
+                sell_orders = orders_df[
+                    (orders_df["is_buy_order"] == 0) & (orders_df["type_id"].isin(requested_ids))
+                ].copy()
                 sell_summary = sell_orders.groupby("type_id", as_index=False).agg(
                     order_type_name=("type_name", "first"),
                     sell_order_price=("price", "min"),
                     sell_order_volume=("volume_remain", "sum"),
                 )
+        if sell_summary is None or sell_summary.empty:
+            sell_summary = pd.DataFrame(
+                columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
+            )
+        else:
+            sell_summary = sell_summary.copy()
+            sell_summary["sell_order_price"] = pd.to_numeric(
+                sell_summary["sell_order_price"], errors="coerce"
+            )
+            sell_summary["sell_order_volume"] = pd.to_numeric(
+                sell_summary["sell_order_volume"], errors="coerce"
+            )
 
         result = base_df.merge(stats_df, on="type_id", how="left").merge(
             sell_summary,
@@ -192,7 +206,6 @@ class MarketService:
             active_buy_orders, items_listed, last_updated.
         """
         stats_df = self._repo.get_all_stats()
-        orders_df = self._repo.get_all_orders()
 
         total_market_value = 0.0
         items_listed = 0
@@ -202,11 +215,19 @@ class MarketService:
             total_market_value = float((prices * volumes).sum())
             items_listed = int(stats_df["type_id"].nunique())
 
-        active_sell_orders = 0
-        active_buy_orders = 0
-        if orders_df is not None and not orders_df.empty:
-            active_sell_orders = int((orders_df["is_buy_order"] == 0).sum())
-            active_buy_orders = int((orders_df["is_buy_order"] == 1).sum())
+        # Order counts come from a SQL GROUP BY rather than loading the full
+        # marketorders table just to count rows by is_buy_order.
+        if hasattr(self._repo, "get_order_counts"):
+            counts = self._repo.get_order_counts()
+            active_sell_orders = int(counts.get("active_sell_orders", 0))
+            active_buy_orders = int(counts.get("active_buy_orders", 0))
+        else:
+            orders_df = self._repo.get_all_orders()
+            active_sell_orders = 0
+            active_buy_orders = 0
+            if orders_df is not None and not orders_df.empty:
+                active_sell_orders = int((orders_df["is_buy_order"] == 0).sum())
+                active_buy_orders = int((orders_df["is_buy_order"] == 1).sum())
 
         last_updated = self._repo.get_update_time()
 

--- a/services/module_equivalents_service.py
+++ b/services/module_equivalents_service.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Optional
 import logging
 import pandas as pd
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 import streamlit as st
 
 from config import DatabaseConfig
@@ -198,6 +198,18 @@ class ModuleEquivalentsService:
         equiv_ids = self.get_equivalent_type_ids(type_id)
         return len(equiv_ids) > 1
 
+    def _build_group_map(self) -> dict[int, EquivalenceGroup]:
+        """Map every type_id in any equivalence group to its group.
+
+        Built from the single cached get_all_equivalence_groups() call so
+        callers can resolve many type_ids without a per-item DB lookup.
+        """
+        group_map: dict[int, EquivalenceGroup] = {}
+        for group in self.get_all_equivalence_groups():
+            for tid in group.type_ids:
+                group_map[tid] = group
+        return group_map
+
     def get_aggregated_stock(self, type_ids: list[int]) -> dict[int, int]:
         """
         Get aggregated stock for each type_id across its equivalents.
@@ -206,22 +218,29 @@ class ModuleEquivalentsService:
         across all equivalent modules. If no equivalents, returns the
         individual module's stock.
 
+        Resolves all groups from one cached query and batches the stock
+        lookup for non-grouped type_ids into a single SQL query, avoiding
+        the previous per-type_id (N+1) round-trips.
+
         Args:
             type_ids: List of type IDs to look up
 
         Returns:
             Dict mapping type_id to aggregated stock
         """
-        result = {}
+        group_map = self._build_group_map()
 
+        result: dict[int, int] = {}
+        ungrouped: list[int] = []
         for type_id in type_ids:
-            group = self.get_equivalence_group(type_id)
+            group = group_map.get(type_id)
             if group:
                 result[type_id] = group.total_stock
             else:
-                # No equivalents, get individual stock
-                stock = self._get_single_module_stock(type_id)
-                result[type_id] = stock
+                ungrouped.append(type_id)
+
+        if ungrouped:
+            result.update(self._get_module_stocks(ungrouped))
 
         return result
 
@@ -232,30 +251,41 @@ class ModuleEquivalentsService:
             Dict mapping type_id to lowest price among in-stock equivalents.
             Only includes entries where a lower-priced equivalent exists.
         """
+        group_map = self._build_group_map()
         result = {}
         for type_id in type_ids:
-            group = self.get_equivalence_group(type_id)
+            group = group_map.get(type_id)
             if group and group.lowest_price > 0:
                 result[type_id] = group.lowest_price
         return result
 
-    def _get_single_module_stock(self, type_id: int) -> int:
-        """Get stock for a single module without equivalents."""
-        query = text("""
-            SELECT total_volume_remain
+    def _get_module_stocks(self, type_ids: list[int]) -> dict[int, int]:
+        """Batch-fetch marketstats stock for modules without equivalents."""
+        if not type_ids:
+            return {}
+        query = text(
+            """
+            SELECT type_id, total_volume_remain
             FROM marketstats
-            WHERE type_id = :type_id
-        """)
-
+            WHERE type_id IN :type_ids
+            """
+        ).bindparams(bindparam("type_ids", expanding=True))
+        result = {int(tid): 0 for tid in type_ids}
         try:
             with self._mkt_db.engine.connect() as conn:
-                result = conn.execute(query, {"type_id": type_id}).fetchone()
-                if result and result[0]:
-                    return int(result[0])
-                return 0
+                rows = conn.execute(
+                    query, {"type_ids": [int(tid) for tid in type_ids]}
+                ).fetchall()
+            for row in rows:
+                if row[1]:
+                    result[int(row[0])] = int(row[1])
         except Exception as e:
-            self._logger.error(f"Failed to get stock for type_id {type_id}: {e}")
-            return 0
+            self._logger.error(f"Failed to batch-get stock for {len(type_ids)} modules: {e}")
+        return result
+
+    def _get_single_module_stock(self, type_id: int) -> int:
+        """Get stock for a single module without equivalents."""
+        return self._get_module_stocks([type_id]).get(type_id, 0)
 
     # -------------------------------------------------------------------------
     # Batch Operations

--- a/services/module_equivalents_service.py
+++ b/services/module_equivalents_service.py
@@ -204,6 +204,12 @@ class ModuleEquivalentsService:
 
         Built from the single cached get_all_equivalence_groups() call so
         callers can resolve many type_ids without a per-item DB lookup.
+
+        Unlike get_equivalence_group(), this does NOT apply the _is_faction()
+        early-exit — it maps every member of every group. Current callers
+        pre-filter their inputs to faction type_ids (via
+        get_type_ids_with_equivalents()), so results match; a future caller
+        passing arbitrary type_ids would resolve any group member here.
         """
         group_map: dict[int, EquivalenceGroup] = {}
         for group in self.get_all_equivalence_groups():
@@ -261,7 +267,14 @@ class ModuleEquivalentsService:
         return result
 
     def _get_module_stocks(self, type_ids: list[int]) -> dict[int, int]:
-        """Batch-fetch marketstats stock for modules without equivalents."""
+        """Batch-fetch marketstats stock for modules without equivalents.
+
+        A type_id the query returns no row for is a genuine 0 (not listed in
+        marketstats). But on a read failure the affected ids are OMITTED, not
+        reported as 0: a failed read must not make a stocked module look
+        out-of-stock (data-integrity rule). Callers treat a missing key as
+        unknown and leave existing values untouched.
+        """
         if not type_ids:
             return {}
         query = text(
@@ -271,20 +284,17 @@ class ModuleEquivalentsService:
             WHERE type_id IN :type_ids
             """
         ).bindparams(bindparam("type_ids", expanding=True))
-        result = {int(tid): 0 for tid in type_ids}
         try:
             repo = BaseRepository(self._mkt_db, self._logger)
             df = repo.read_df(query, params={"type_ids": [int(tid) for tid in type_ids]})
-            for _, row in df.iterrows():
-                if row["total_volume_remain"]:
-                    result[int(row["type_id"])] = int(row["total_volume_remain"])
         except Exception as e:
             self._logger.error(f"Failed to batch-get stock for {len(type_ids)} modules: {e}")
+            return {}
+        result = {int(tid): 0 for tid in type_ids}
+        for _, row in df.iterrows():
+            if row["total_volume_remain"]:
+                result[int(row["type_id"])] = int(row["total_volume_remain"])
         return result
-
-    def _get_single_module_stock(self, type_id: int) -> int:
-        """Get stock for a single module without equivalents."""
-        return self._get_module_stocks([type_id]).get(type_id, 0)
 
     # -------------------------------------------------------------------------
     # Batch Operations

--- a/services/module_equivalents_service.py
+++ b/services/module_equivalents_service.py
@@ -19,6 +19,7 @@ import streamlit as st
 
 from config import DatabaseConfig
 from logging_config import setup_logging
+from repositories.base import BaseRepository
 
 logger = setup_logging(__name__, log_file="module_equivalents_service.log")
 
@@ -272,13 +273,11 @@ class ModuleEquivalentsService:
         ).bindparams(bindparam("type_ids", expanding=True))
         result = {int(tid): 0 for tid in type_ids}
         try:
-            with self._mkt_db.engine.connect() as conn:
-                rows = conn.execute(
-                    query, {"type_ids": [int(tid) for tid in type_ids]}
-                ).fetchall()
-            for row in rows:
-                if row[1]:
-                    result[int(row[0])] = int(row[1])
+            repo = BaseRepository(self._mkt_db, self._logger)
+            df = repo.read_df(query, params={"type_ids": [int(tid) for tid in type_ids]})
+            for _, row in df.iterrows():
+                if row["total_volume_remain"]:
+                    result[int(row["type_id"])] = int(row["total_volume_remain"])
         except Exception as e:
             self._logger.error(f"Failed to batch-get stock for {len(type_ids)} modules: {e}")
         return result

--- a/services/price_service.py
+++ b/services/price_service.py
@@ -192,7 +192,11 @@ class FuzzworkProvider:
     """
     Price provider using Fuzzwork API.
 
-    This is the primary Jita price source.
+    NOT in the default provider chain. Jita prices are served from the
+    backend-populated ``jita_prices`` table (see ``DatabasePriceProvider``
+    and ``JitaPriceService.create_default``). This class is retained for
+    explicit / out-of-band use only; wiring it back into the request path
+    reintroduces a blocking network call with a per-chunk ``time.sleep``.
     """
 
     BASE_URL = "https://market.fuzzwork.co.uk/aggregates/"
@@ -296,7 +300,10 @@ class JaniceProvider:
     """
     Price provider using Janice API.
 
-    Used as fallback when Fuzzwork fails.
+    NOT in the default provider chain. Jita prices are served from the
+    backend-populated ``jita_prices`` table (see ``DatabasePriceProvider``
+    and ``JitaPriceService.create_default``). This class is retained for
+    explicit / out-of-band use only.
     """
 
     BASE_URL = "https://janice.e-351.com/api/rest/v2/pricer"
@@ -748,19 +755,23 @@ class JitaPriceService:
         Factory method to create service with default configuration.
 
         This is the recommended way to instantiate the service.
+
+        Jita prices are served exclusively from the backend-populated
+        ``jita_prices`` table via ``DatabasePriceProvider``. The live-API
+        providers (Fuzzwork, Janice) are intentionally NOT wired into the
+        default chain: Jita data is now produced by the backend pipeline,
+        and falling back to a live API in the request path reintroduced the
+        blocking network call (and per-chunk ``time.sleep``) this app no
+        longer wants. The provider classes remain available for explicit /
+        out-of-band use, and ``janice_api_key`` is accepted only for
+        backward-compatible call sites (it is ignored here).
         """
         logger = logging.getLogger(__name__)
 
-        # Build provider chain: DB cache (fast) -> Fuzzwork -> Janice
+        # Provider chain: backend jita_prices DB cache only.
         providers = []
-
         if db_config:
             providers.append(DatabasePriceProvider(db_config, logger))
-
-        providers.append(FuzzworkProvider(logger))
-
-        if janice_api_key:
-            providers.append(JaniceProvider(janice_api_key, logger))
 
         jita_provider = FallbackPriceProvider(providers, logger)
 

--- a/services/price_service.py
+++ b/services/price_service.py
@@ -957,7 +957,16 @@ class JitaPriceService:
         return df
 
     def _cache_result(self, type_id: TypeID, result: PriceResult) -> None:
-        """Store a price result with its cache timestamp."""
+        """Store a price result with its cache timestamp.
+
+        Note: failure results are cached too (negative caching), for the same
+        ``cache_ttl``. So after the backend repopulates an empty/stale
+        ``jita_prices`` table, an in-memory "unavailable" entry can persist for
+        up to ``cache_ttl`` seconds before it is re-fetched. This is accepted:
+        it bounds request pressure, and a stale unavailable is shown as a blank
+        ("—"), never a misleading 0. Lower ``cache_ttl`` if faster recovery is
+        needed.
+        """
         with _PRICE_CACHE_LOCK:
             self._price_cache[type_id] = CachedPriceEntry(
                 result=result,

--- a/tests/test_import_helper_service.py
+++ b/tests/test_import_helper_service.py
@@ -741,3 +741,75 @@ class TestImportHelperService:
 
         assert result["category_id"].tolist() == [4, 7]
         assert result["category_name"].tolist() == ["Mineral", "Ship Equipment"]
+
+
+class TestJitaPriceHelpersReturnNaNForMissing:
+    """_get_jita_sell_price/_get_jita_buy_price: missing/failed -> NaN, not 0.
+
+    A 0 would make an unpriced item look free at Jita and fabricate a huge
+    import margin (data-integrity rule).
+    """
+
+    def test_missing_id_returns_nan(self):
+        from services.import_helper_service import (
+            _get_jita_buy_price,
+            _get_jita_sell_price,
+        )
+
+        assert pd.isna(_get_jita_sell_price({}, 34))
+        assert pd.isna(_get_jita_buy_price({}, 34))
+
+    def test_failed_result_returns_nan(self):
+        from services.import_helper_service import (
+            _get_jita_buy_price,
+            _get_jita_sell_price,
+        )
+
+        prices = {34: PriceResult.failure_result(34, "Not found")}
+        assert pd.isna(_get_jita_sell_price(prices, 34))
+        assert pd.isna(_get_jita_buy_price(prices, 34))
+
+    def test_successful_result_returns_value(self):
+        from services.import_helper_service import (
+            _get_jita_buy_price,
+            _get_jita_sell_price,
+        )
+
+        prices = {
+            34: PriceResult.success_result(
+                type_id=34, sell_price=20.0, buy_price=18.0,
+                source=PriceSource.JITA_FUZZWORK,
+            )
+        }
+        assert _get_jita_sell_price(prices, 34) == 20.0
+        assert _get_jita_buy_price(prices, 34) == 18.0
+
+
+class TestMissingJitaPriceIsNotFakeMargin:
+    """An item with a local price but no Jita price must not top the list."""
+
+    def test_item_without_jita_price_is_excluded_not_shown_as_fake_margin(self):
+        from services.import_helper_service import ImportHelperService
+
+        service = ImportHelperService(
+            Mock(), Mock(), DummyPriceService({}), _mock_market_repo({34: 150.0})
+        )
+        service._price_service = DummyPriceService({})  # no Jita price for 34
+        with patch.object(
+            service,
+            "_get_import_candidates",
+            return_value=pd.DataFrame({
+                "type_id": [34],
+                "type_name": ["Tritanium"],
+                "price": [30.0],
+                "volume_m3": [0.01],
+                "category_name": ["Mineral"],
+                "group_name": ["Mineral"],
+            }),
+        ):
+            base_df = service.fetch_base_data()
+            result = service.get_import_items(base_df)
+
+        # No Jita price -> profit is NaN, so the item must NOT masquerade as a
+        # screaming-margin opportunity; profitable_only (default) excludes it.
+        assert 34 not in result["type_id"].values

--- a/tests/test_market_dashboard.py
+++ b/tests/test_market_dashboard.py
@@ -14,12 +14,19 @@ import pytest
 class TestGetMarketOverviewKpis:
     """Tests for MarketService.get_market_overview_kpis()."""
 
-    def _make_service(self, stats_df=None, orders_df=None, update_time="12:00 UTC"):
+    def _make_service(
+        self, stats_df=None, order_counts=None, update_time="12:00 UTC",
+    ):
         from services.market_service import MarketService
 
         repo = MagicMock()
         repo.get_all_stats.return_value = stats_df
-        repo.get_all_orders.return_value = orders_df
+        # Order counts now come from a SQL GROUP BY in the repository, not a
+        # full-table pandas load. Default to zeros when not provided.
+        repo.get_order_counts.return_value = order_counts or {
+            "active_sell_orders": 0,
+            "active_buy_orders": 0,
+        }
         repo.get_update_time.return_value = update_time
         return MarketService(repo)
 
@@ -29,10 +36,10 @@ class TestGetMarketOverviewKpis:
             "min_price": [10.0, 20.0],
             "total_volume_remain": [100, 200],
         })
-        orders = pd.DataFrame({
-            "is_buy_order": [0, 0, 1],
-        })
-        service = self._make_service(stats_df=stats, orders_df=orders)
+        service = self._make_service(
+            stats_df=stats,
+            order_counts={"active_sell_orders": 2, "active_buy_orders": 1},
+        )
         kpis = service.get_market_overview_kpis()
 
         assert kpis["total_market_value"] == pytest.approx(10.0 * 100 + 20.0 * 200)
@@ -43,7 +50,7 @@ class TestGetMarketOverviewKpis:
 
     def test_empty_data_returns_zeros(self):
         service = self._make_service(
-            stats_df=pd.DataFrame(), orders_df=pd.DataFrame(), update_time=None,
+            stats_df=pd.DataFrame(), order_counts=None, update_time=None,
         )
         kpis = service.get_market_overview_kpis()
 
@@ -54,7 +61,7 @@ class TestGetMarketOverviewKpis:
         assert kpis["last_updated"] is None
 
     def test_none_dataframes(self):
-        service = self._make_service(stats_df=None, orders_df=None)
+        service = self._make_service(stats_df=None, order_counts=None)
         kpis = service.get_market_overview_kpis()
 
         assert kpis["total_market_value"] == 0.0
@@ -68,7 +75,7 @@ class TestGetMarketOverviewKpis:
             "min_price": ["not_a_number"],
             "total_volume_remain": [100],
         })
-        service = self._make_service(stats_df=stats, orders_df=pd.DataFrame())
+        service = self._make_service(stats_df=stats, order_counts=None)
         kpis = service.get_market_overview_kpis()
 
         assert kpis["total_market_value"] == 0.0

--- a/tests/test_market_dashboard.py
+++ b/tests/test_market_dashboard.py
@@ -319,6 +319,12 @@ class TestJitaDiffCellStyle:
 
         assert _jita_diff_cell_style(0.0) == "color: #728049"
 
+    def test_nan_returns_empty(self):
+        """A missing % vs Jita (NaN) gets no color — the cell renders blank."""
+        from pages.components.dashboard_components import _jita_diff_cell_style
+
+        assert _jita_diff_cell_style(float("nan")) == ""
+
 
 class TestComputeShipTargetPct:
     """Tests for _compute_ship_target_pct() — the per-ship progress helper."""
@@ -521,3 +527,178 @@ class TestRenderPopularModulesTableEarlyExits:
         with patch.object(dc, "_compute_module_targets", return_value=targets):
             result = dc.render_popular_modules_table(**kwargs)
         assert result == (None, None)
+
+
+# =========================================================================
+# Jita price NA handling (missing Jita price must render blank, never 0)
+# =========================================================================
+
+
+class TestJitaPriceOrNa:
+    """_jita_price_or_na: a missing/failed Jita result is NaN, not a fake 0."""
+
+    def test_none_returns_nan(self):
+        from pages.components.dashboard_components import _jita_price_or_na
+
+        assert pd.isna(_jita_price_or_na(None, "sell_price"))
+
+    def test_failed_result_returns_nan(self):
+        from types import SimpleNamespace
+        from pages.components.dashboard_components import _jita_price_or_na
+
+        failed = SimpleNamespace(success=False, sell_price=0.0, buy_price=0.0)
+        assert pd.isna(_jita_price_or_na(failed, "sell_price"))
+        assert pd.isna(_jita_price_or_na(failed, "buy_price"))
+
+    def test_successful_result_returns_value(self):
+        from types import SimpleNamespace
+        from pages.components.dashboard_components import _jita_price_or_na
+
+        ok = SimpleNamespace(success=True, sell_price=8.0, buy_price=7.0)
+        assert _jita_price_or_na(ok, "sell_price") == 8.0
+        assert _jita_price_or_na(ok, "buy_price") == 7.0
+
+
+class TestAddJitaPrices:
+    """_add_jita_prices: missing/failed prices stay NaN so they render '—'."""
+
+    def test_missing_or_failed_prices_render_as_nan_not_zero(self):
+        from types import SimpleNamespace
+        from pages.components.dashboard_components import _add_jita_prices
+
+        df = pd.DataFrame({
+            "type_id": [34, 35, 36],
+            "current_sell_price": [10.0, 20.0, 30.0],
+        })
+        price_map = {
+            34: SimpleNamespace(success=True, sell_price=8.0, buy_price=7.0),
+            # 35: a backfilled failure result (success False, price 0)
+            35: SimpleNamespace(success=False, sell_price=0.0, buy_price=0.0),
+            # 36: absent from the map entirely
+        }
+
+        result = _add_jita_prices(df, price_map).set_index("type_id")
+
+        # Priced item keeps real values and a computed % diff
+        assert result.loc[34, "jita_sell_price"] == 8.0
+        assert result.loc[34, "pct_diff_vs_jita_sell"] == pytest.approx(
+            (10.0 - 8.0) / 8.0 * 100
+        )
+        # A missing Jita price is NOT "free at Jita" — must be NaN, never 0
+        for missing_tid in (35, 36):
+            assert pd.isna(result.loc[missing_tid, "jita_sell_price"])
+            assert pd.isna(result.loc[missing_tid, "jita_buy_price"])
+            assert pd.isna(result.loc[missing_tid, "pct_diff_vs_jita_sell"])
+
+
+class TestCoerceNumericFillValue:
+    """_coerce_numeric: fill_value=None preserves NaN (for Jita columns)."""
+
+    def test_default_fills_nan_with_zero(self):
+        from pages.components.dashboard_components import _coerce_numeric
+
+        df = pd.DataFrame({"x": [1.0, None]})
+        out = _coerce_numeric(df, ["x"])
+        assert out["x"].tolist() == [1.0, 0.0]
+
+    def test_fill_value_none_preserves_nan(self):
+        from pages.components.dashboard_components import _coerce_numeric
+
+        df = pd.DataFrame({"x": [1.0, None]})
+        out = _coerce_numeric(df, ["x"], fill_value=None)
+        assert out["x"].iloc[0] == 1.0
+        assert pd.isna(out["x"].iloc[1])
+
+
+# =========================================================================
+# _apply_equivalents_to_fits (vectorized) — regression lock vs the old loop
+# =========================================================================
+
+
+class TestApplyEquivalentsToFits:
+    """The vectorized update must reproduce the original per-row loop:
+    fit_qty > 0 -> total_stock // fit_qty; fit_qty <= 0 -> total_stock;
+    type_id with no aggregated stock -> left untouched.
+    """
+
+    def test_vectorized_update_matches_loop_semantics(self):
+        from pages.components import dashboard_components as dc
+
+        fits_df = pd.DataFrame({
+            "type_id": [100, 101, 102, 999],
+            "fit_qty": [3, 1, 0, 2],
+            "fits_on_mkt": [-1, -1, -1, 7],  # 999 has no equivalent -> stays 7
+        })
+        aggregated = {100: 10, 101: 5, 102: 8}  # 999 absent
+
+        equiv = MagicMock()
+        equiv.get_type_ids_with_equivalents.return_value = [100, 101, 102]
+        equiv.get_aggregated_stock.return_value = aggregated
+
+        with patch("settings_service.SettingsService") as mock_settings, patch(
+            "services.module_equivalents_service.get_module_equivalents_service",
+            return_value=equiv,
+        ):
+            mock_settings.return_value.use_equivalents = True
+            result = dc._apply_equivalents_to_fits(fits_df).set_index("type_id")
+
+        assert result.loc[100, "fits_on_mkt"] == 10 // 3  # floor division -> 3
+        assert result.loc[101, "fits_on_mkt"] == 5 // 1   # -> 5
+        assert result.loc[102, "fits_on_mkt"] == 8        # fit_qty 0 -> total_stock
+        assert result.loc[999, "fits_on_mkt"] == 7        # untouched
+
+
+# =========================================================================
+# _require_jita_prices — total-outage guard (data-integrity)
+# =========================================================================
+
+
+class TestRequireJitaPrices:
+    """Bails (None + st.error) only on a TOTAL outage; passes the map through
+    when at least one item is priced; an empty request is not an outage.
+    """
+
+    def _price_service(self, prices):
+        ps = MagicMock()
+        ps.get_jita_prices.return_value.prices = prices
+        return ps
+
+    def test_total_outage_returns_none_and_surfaces_error(self):
+        from types import SimpleNamespace
+        from pages.components import dashboard_components as dc
+
+        prices = {
+            34: SimpleNamespace(success=False, sell_price=0.0),
+            35: SimpleNamespace(success=False, sell_price=0.0),
+        }
+        ps = self._price_service(prices)
+        with patch.object(dc, "st") as mock_st:
+            result = dc._require_jita_prices(ps, [34, 35])
+
+        assert result is None
+        mock_st.error.assert_called_once()
+
+    def test_partial_availability_returns_map_without_error(self):
+        from types import SimpleNamespace
+        from pages.components import dashboard_components as dc
+
+        prices = {
+            34: SimpleNamespace(success=True, sell_price=8.0),
+            35: SimpleNamespace(success=False, sell_price=0.0),
+        }
+        ps = self._price_service(prices)
+        with patch.object(dc, "st") as mock_st:
+            result = dc._require_jita_prices(ps, [34, 35])
+
+        assert result is prices
+        mock_st.error.assert_not_called()
+
+    def test_empty_type_ids_is_not_an_outage(self):
+        from pages.components import dashboard_components as dc
+
+        ps = self._price_service({})
+        with patch.object(dc, "st") as mock_st:
+            result = dc._require_jita_prices(ps, [])
+
+        assert result == {}
+        mock_st.error.assert_not_called()

--- a/tests/test_market_repo.py
+++ b/tests/test_market_repo.py
@@ -438,3 +438,151 @@ class TestMarketRepositoryFactory:
             from repositories.market_repo import get_market_repository
             repo = get_market_repository()
             assert isinstance(repo, MarketRepository)
+
+
+class TestSellOrderSummaryImpl:
+    """Test the SQL-aggregated sell-order summary used by the dashboard snapshot."""
+
+    def test_empty_type_ids_returns_empty_frame_without_query(self):
+        """Empty input short-circuits — no DB access, correct columns."""
+        from repositories.market_repo import _get_sell_order_summary_impl
+
+        with patch("repositories.market_repo.BaseRepository") as mock_repo_cls:
+            result = _get_sell_order_summary_impl([])
+
+        assert list(result.columns) == [
+            "type_id", "order_type_name", "sell_order_price", "sell_order_volume"
+        ]
+        assert result.empty
+        mock_repo_cls.assert_not_called()
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_pushes_sell_filter_and_aggregation_into_sql(self, mock_db_cls, mock_repo_cls):
+        """Query filters to sell orders and aggregates per type_id; ids coerced to int."""
+        expected = pd.DataFrame({
+            "type_id": [34],
+            "order_type_name": ["Tritanium"],
+            "sell_order_price": [5.0],
+            "sell_order_volume": [300],
+        })
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = expected
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_sell_order_summary_impl
+        result = _get_sell_order_summary_impl(["34"])
+
+        assert result.equals(expected)
+        query = str(mock_repo.read_df.call_args[0][0])
+        assert "is_buy_order = 0" in query
+        assert "GROUP BY type_id" in query
+        assert mock_repo.read_df.call_args[1]["params"]["type_ids"] == [34]
+
+
+class TestStatsForTypeIdsImpl:
+    """Test the SQL-filtered marketstats fetch."""
+
+    def test_empty_type_ids_returns_empty_frame_without_query(self):
+        from repositories.market_repo import _get_stats_for_type_ids_impl
+
+        with patch("repositories.market_repo.BaseRepository") as mock_repo_cls:
+            result = _get_stats_for_type_ids_impl([])
+
+        assert list(result.columns) == [
+            "type_id", "type_name", "min_price", "total_volume_remain"
+        ]
+        assert result.empty
+        mock_repo_cls.assert_not_called()
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_filters_marketstats_by_type_ids(self, mock_db_cls, mock_repo_cls):
+        expected = pd.DataFrame({
+            "type_id": [34, 35],
+            "type_name": ["Tritanium", "Pyerite"],
+            "min_price": [5.0, 6.0],
+            "total_volume_remain": [1000, 2000],
+        })
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = expected
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_stats_for_type_ids_impl
+        result = _get_stats_for_type_ids_impl([34, 35])
+
+        assert result.equals(expected)
+        query = str(mock_repo.read_df.call_args[0][0])
+        assert "FROM marketstats" in query
+        assert mock_repo.read_df.call_args[1]["params"]["type_ids"] == [34, 35]
+
+
+class TestOrderCountsImpl:
+    """Test the SQL GROUP BY order-count aggregation."""
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_maps_is_buy_order_to_sell_and_buy_counts(self, mock_db_cls, mock_repo_cls):
+        """is_buy_order 0 -> active_sell_orders, 1 -> active_buy_orders."""
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = pd.DataFrame(
+            {"is_buy_order": [0, 1], "n": [5, 3]}
+        )
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_order_counts_impl
+        result = _get_order_counts_impl()
+
+        assert result == {"active_sell_orders": 5, "active_buy_orders": 3}
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_missing_buy_group_defaults_to_zero(self, mock_db_cls, mock_repo_cls):
+        """A market with only sell orders reports buy count 0 (a true zero)."""
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = pd.DataFrame({"is_buy_order": [0], "n": [5]})
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_order_counts_impl
+        result = _get_order_counts_impl()
+
+        assert result == {"active_sell_orders": 5, "active_buy_orders": 0}
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_empty_frame_returns_zeros(self, mock_db_cls, mock_repo_cls):
+        """A genuinely empty result is a true zero, not an error."""
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = pd.DataFrame(columns=["is_buy_order", "n"])
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_order_counts_impl
+        result = _get_order_counts_impl()
+
+        assert result == {"active_sell_orders": 0, "active_buy_orders": 0}
+
+    @patch("repositories.market_repo.BaseRepository")
+    @patch("repositories.market_repo.DatabaseConfig")
+    def test_read_failure_propagates_rather_than_reporting_zero(
+        self, mock_db_cls, mock_repo_cls
+    ):
+        """An unrecoverable read failure must NOT be reported as 0 orders.
+
+        read_df() already attempts sync + remote recovery before raising; if it
+        still raises, the failure is genuine. Returning {0, 0} would misreport a
+        broken read as a real empty market (data-integrity rule). The error must
+        propagate so the page surfaces it instead of a fake KPI.
+        """
+        mock_repo = Mock()
+        mock_repo.read_df.side_effect = RuntimeError("database disk image is malformed")
+        mock_repo_cls.return_value = mock_repo
+        mock_db_cls.return_value = Mock()
+
+        from repositories.market_repo import _get_order_counts_impl
+        with pytest.raises(RuntimeError):
+            _get_order_counts_impl()

--- a/tests/test_market_service.py
+++ b/tests/test_market_service.py
@@ -451,7 +451,11 @@ class TestGetCurrentMarketSnapshot:
     """Test fixed-item current market snapshot aggregation."""
 
     def test_prefers_live_sell_orders_for_price_and_volume(self, mock_repo):
-        mock_repo.get_all_stats.return_value = pd.DataFrame(
+        # Snapshot now pulls only the requested rows via SQL-filtered repo
+        # methods (get_stats_for_type_ids / get_sell_order_summary). The
+        # sell-order aggregation (min price, summed volume) happens in SQL,
+        # so the mock returns the already-aggregated summary.
+        mock_repo.get_stats_for_type_ids.return_value = pd.DataFrame(
             {
                 "type_id": [34],
                 "type_name": ["Tritanium"],
@@ -459,13 +463,12 @@ class TestGetCurrentMarketSnapshot:
                 "total_volume_remain": [1000],
             }
         )
-        mock_repo.get_all_orders.return_value = pd.DataFrame(
+        mock_repo.get_sell_order_summary.return_value = pd.DataFrame(
             {
-                "type_id": [34, 34, 34],
-                "type_name": ["Tritanium", "Tritanium", "Tritanium"],
-                "price": [5.0, 5.2, 4.8],
-                "volume_remain": [100, 200, 300],
-                "is_buy_order": [0, 0, 1],
+                "type_id": [34],
+                "order_type_name": ["Tritanium"],
+                "sell_order_price": [5.0],
+                "sell_order_volume": [300],
             }
         )
 
@@ -479,7 +482,7 @@ class TestGetCurrentMarketSnapshot:
         assert result.iloc[0]["order_volume"] == pytest.approx(300.0)
 
     def test_falls_back_to_marketstats_when_no_sell_orders_exist(self, mock_repo):
-        mock_repo.get_all_stats.return_value = pd.DataFrame(
+        mock_repo.get_stats_for_type_ids.return_value = pd.DataFrame(
             {
                 "type_id": [34, 35],
                 "type_name": ["Tritanium", "Pyerite"],
@@ -487,8 +490,8 @@ class TestGetCurrentMarketSnapshot:
                 "total_volume_remain": [1000, 2000],
             }
         )
-        mock_repo.get_all_orders.return_value = pd.DataFrame(
-            columns=["type_id", "type_name", "price", "volume_remain", "is_buy_order"]
+        mock_repo.get_sell_order_summary.return_value = pd.DataFrame(
+            columns=["type_id", "order_type_name", "sell_order_price", "sell_order_volume"]
         )
 
         from services.market_service import MarketService

--- a/tests/test_module_equivalents_service.py
+++ b/tests/test_module_equivalents_service.py
@@ -1,0 +1,117 @@
+"""
+Tests for ModuleEquivalentsService.
+
+Covers the batched/grouped stock resolution introduced in the loading-performance
+pass:
+- _build_group_map (single cached groups call -> type_id -> group map)
+- get_aggregated_stock (grouped ids served from the group, ungrouped batched)
+- get_equivalent_lowest_prices
+- _get_module_stocks (batch marketstats read; missing id = true 0;
+  read failure = OMIT ids, never a fabricated 0 stock)
+"""
+from unittest.mock import Mock, patch
+
+import pandas as pd
+
+from services.module_equivalents_service import (
+    EquivalenceGroup,
+    EquivalentModule,
+    ModuleEquivalentsService,
+)
+
+
+def _make_service():
+    """Service with a mock DatabaseConfig (alias/engine attributes only)."""
+    mock_db = Mock()
+    mock_db.alias = "wcmkt"
+    return ModuleEquivalentsService(mock_db)
+
+
+def _group(group_id, *modules):
+    return EquivalenceGroup(
+        equiv_group_id=group_id,
+        modules=[EquivalentModule(*m) for m in modules],
+    )
+
+
+class TestBuildGroupMap:
+    def test_maps_every_member_type_id_to_its_group(self):
+        service = _make_service()
+        group_a = _group(1, (100, "A1", 10, 5.0), (101, "A2", 20, 6.0))
+        group_b = _group(2, (200, "B1", 3, 9.0))
+        service.get_all_equivalence_groups = Mock(return_value=[group_a, group_b])
+
+        group_map = service._build_group_map()
+
+        assert group_map[100] is group_a
+        assert group_map[101] is group_a
+        assert group_map[200] is group_b
+        assert set(group_map) == {100, 101, 200}
+
+
+class TestGetAggregatedStock:
+    def test_grouped_ids_use_total_stock_ungrouped_are_batched(self):
+        service = _make_service()
+        group = _group(1, (100, "A1", 10, 5.0), (101, "A2", 20, 6.0))  # total_stock=30
+        service.get_all_equivalence_groups = Mock(return_value=[group])
+
+        with patch.object(
+            service, "_get_module_stocks", return_value={200: 50}
+        ) as mock_batch:
+            result = service.get_aggregated_stock([100, 101, 200])
+
+        assert result == {100: 30, 101: 30, 200: 50}
+        # N+1 elimination: a single batched call for all ungrouped ids.
+        mock_batch.assert_called_once_with([200])
+
+
+class TestGetEquivalentLowestPrices:
+    def test_returns_lowest_price_only_for_grouped_in_stock_ids(self):
+        service = _make_service()
+        group = _group(1, (100, "A1", 10, 7.0), (101, "A2", 20, 5.0))  # lowest=5.0
+        service.get_all_equivalence_groups = Mock(return_value=[group])
+
+        result = service.get_lowest_equivalent_prices([100, 101, 999])
+
+        assert result == {100: 5.0, 101: 5.0}  # 999 is ungrouped -> omitted
+
+
+class TestGetModuleStocks:
+    @patch("services.module_equivalents_service.BaseRepository")
+    def test_present_ids_get_stock_absent_ids_are_true_zero(self, mock_repo_cls):
+        service = _make_service()
+        mock_repo = Mock()
+        mock_repo.read_df.return_value = pd.DataFrame(
+            {"type_id": [34], "total_volume_remain": [1000]}
+        )
+        mock_repo_cls.return_value = mock_repo
+
+        # 34 present in marketstats -> 1000; 35 absent -> genuine 0.
+        result = service._get_module_stocks([34, 35])
+
+        assert result == {34: 1000, 35: 0}
+
+    def test_empty_input_returns_empty_without_query(self):
+        service = _make_service()
+        with patch("services.module_equivalents_service.BaseRepository") as mock_repo_cls:
+            result = service._get_module_stocks([])
+        assert result == {}
+        mock_repo_cls.assert_not_called()
+
+    @patch("services.module_equivalents_service.BaseRepository")
+    def test_read_failure_omits_ids_rather_than_reporting_zero_stock(self, mock_repo_cls):
+        """A read failure must NOT report modules as 0 stock.
+
+        Returning {tid: 0} would make a well-stocked doctrine item render as
+        out-of-stock when the DB read merely failed (data-integrity rule). The
+        ids are omitted so callers treat them as unknown and leave existing
+        values untouched, rather than fabricating a zero.
+        """
+        service = _make_service()
+        mock_repo = Mock()
+        mock_repo.read_df.side_effect = RuntimeError("database disk image is malformed")
+        mock_repo_cls.return_value = mock_repo
+
+        result = service._get_module_stocks([34, 35])
+
+        assert result == {}  # omitted, NOT {34: 0, 35: 0}

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -121,7 +121,7 @@ def test_jita_cache_persists_across_market_switches():
     with (
         patch("services.price_service.DatabaseConfig", return_value=SimpleNamespace()),
         patch("services.price_service.LocalMarketProvider", return_value=Mock()),
-        patch("services.price_service.FuzzworkProvider", return_value=shared_provider),
+        patch("services.price_service.DatabasePriceProvider", return_value=shared_provider),
     ):
         b9_service = price_service_module.get_price_service(
             db_alias="wcmktprod",
@@ -167,6 +167,31 @@ def test_get_jita_prices_dedupes_uncached_type_ids():
 
     assert sorted(result.prices) == [34, 35]
     assert provider.calls == 2
+
+
+def test_default_chain_excludes_live_api_providers():
+    """create_default must NOT wire Fuzzwork/Janice into the request path.
+
+    Jita prices come solely from the backend-populated jita_prices table via
+    DatabasePriceProvider; live-API fallback was removed to eliminate blocking
+    network calls (and per-chunk sleeps) during page renders.
+    """
+    from types import SimpleNamespace
+
+    from services.price_service import (
+        JitaPriceService,
+        DatabasePriceProvider,
+        FuzzworkProvider,
+        JaniceProvider,
+    )
+
+    service = JitaPriceService.create_default(
+        db_config=SimpleNamespace(), janice_api_key="ignored"
+    )
+    providers = service._jita_provider._providers
+
+    assert any(isinstance(p, DatabasePriceProvider) for p in providers)
+    assert not any(isinstance(p, (FuzzworkProvider, JaniceProvider)) for p in providers)
 
 
 def test_fuzzwork_provider_chunks_requests_and_sleeps_between_chunks():


### PR DESCRIPTION
This PR improves loading performance of market dashboard. 1) Adds methods to market repo to pre-filter data pulls. Previously, db call was loading all market stats data and filtering the resulting Pandas DataFrames to populate each dashboard table (5 total) on every re-run.  2) Batch data lookup and vectorize resolution of module equivalents. Previously we were looking up each module individually  in a loop. 3) Deprecate live API calls for Jita prices. We populate the Jita price table in the database in our hourly backend database updates. There should be no need for an API fallback for Jita in the frontend app. The backend already ensures the Jita Price table is populated with backups in case an API is down. If the Jita price table is not populated, something has gone very wrong. We will fail loudly instead. Also, updated architecture rules to prefer BaseRepository.read_df() with raw SQL as standard convention for DB reads.