### PR TITLE
Add export options for low-stock modules page

### DIFF
--- a/pages/low_stock.py
+++ b/pages/low_stock.py
@@ -28,6 +28,7 @@ from ui.sync_display import display_sync_status
 logger = setup_logging(__name__, log_file="low_stock.log")
 
 # Columns written to the export CSV (visible table + the computed restock qty).
+# Keep in sync with columns_to_show in main().
 EXPORT_CSV_COLUMNS = [
     "type_id",
     "type_name",
@@ -35,19 +36,24 @@ EXPORT_CSV_COLUMNS = [
     "price",
     "days_remaining",
     "total_volume_remain",
+    "fits_on_mkt",
     "avg_volume",
     "category_name",
     "group_name",
     "ships",
 ]
+# Columns only present in some page modes (fits_on_mkt appears in single-fit mode).
+OPTIONAL_EXPORT_COLUMNS = {"fits_on_mkt"}
 
 
 def compute_restock_qty(avg_volume: float, max_days: float, current_stock: float) -> int:
     """Quantity to buy to restock an item to ``max_days`` days of stock.
 
     ``avg_volume`` is 30-day average daily sales, ``current_stock`` is the
-    quantity currently on the market. Floored at 1 so a ticked row never
-    exports as a zero/negative multibuy quantity.
+    quantity currently on the market. Floored at 1 by design: a 0 quantity
+    breaks the multibuy format for third-party tools, and a ticked row is an
+    explicit request to include the item even if the stock math says it
+    needs nothing (decided 2026-06-10, PR #73 review).
     """
     return max(1, int(round(avg_volume * max_days - current_stock)))
 
@@ -186,6 +192,12 @@ def _render_low_stock_export(edited_df, max_days: float, language_code: str) -> 
     export["ships"] = export["ships"].apply(
         lambda s: "; ".join(s) if isinstance(s, list) else (s or "")
     )
+    missing = [
+        c for c in EXPORT_CSV_COLUMNS
+        if c not in export.columns and c not in OPTIONAL_EXPORT_COLUMNS
+    ]
+    if missing:
+        logger.error("Low stock export is missing expected columns: %s", missing)
     csv_cols = [c for c in EXPORT_CSV_COLUMNS if c in export.columns]
     csv = export[csv_cols].to_csv(index=False)
     st.download_button(

--- a/pages/low_stock.py
+++ b/pages/low_stock.py
@@ -27,6 +27,29 @@ from init_db import ensure_market_db_ready
 from ui.sync_display import display_sync_status
 logger = setup_logging(__name__, log_file="low_stock.log")
 
+# Columns written to the export CSV (visible table + the computed restock qty).
+EXPORT_CSV_COLUMNS = [
+    "type_id",
+    "type_name",
+    "restock_qty",
+    "price",
+    "days_remaining",
+    "total_volume_remain",
+    "avg_volume",
+    "category_name",
+    "group_name",
+    "ships",
+]
+
+
+def compute_restock_qty(avg_volume: float, max_days: float, current_stock: float) -> int:
+    """Quantity to buy to restock an item to ``max_days`` days of stock.
+
+    ``avg_volume`` is 30-day average daily sales, ``current_stock`` is the
+    quantity currently on the market. Floored at 1 so a ticked row never
+    exports as a zero/negative multibuy quantity.
+    """
+    return max(1, int(round(avg_volume * max_days - current_stock)))
 
 
 def create_days_remaining_chart(df: pd.DataFrame, language_code: str):
@@ -124,6 +147,53 @@ def display_fit_data(selected_fit):
         st.markdown(
             f"fits: :orange[{fits}] | hulls: :orange[{hulls}] | target: :orange[{target}]"
         )
+
+
+def _render_low_stock_export(edited_df, max_days: float, language_code: str) -> None:
+    """Render an EVE-Multibuy code block and CSV download for ticked rows.
+
+    Each multibuy line is ``type_name<TAB>restock_qty``, where the quantity
+    restocks the item to ``max_days`` days of stock — paste-ready for EVE
+    Multibuy / JEveAssets. The CSV mirrors the visible table plus the computed
+    restock quantity.
+    """
+    st.subheader(translate_text(language_code, "low_stock.export_header"))
+    selected = edited_df[edited_df["select"]]
+    if selected.empty:
+        st.caption(translate_text(language_code, "low_stock.export_no_selection"))
+        return
+
+    st.caption(
+        translate_text(language_code, "low_stock.export_qty_caption", days=f"{max_days:g}")
+    )
+
+    export = selected.copy()
+    export["restock_qty"] = [
+        compute_restock_qty(
+            avg_volume=row.avg_volume,
+            max_days=max_days,
+            current_stock=row.total_volume_remain,
+        )
+        for row in export.itertuples(index=False)
+    ]
+
+    multibuy = "\n".join(
+        f"{row.type_name}\t{row.restock_qty}"
+        for row in export.itertuples(index=False)
+    )
+    st.code(multibuy, language=None)
+
+    export["ships"] = export["ships"].apply(
+        lambda s: "; ".join(s) if isinstance(s, list) else (s or "")
+    )
+    csv_cols = [c for c in EXPORT_CSV_COLUMNS if c in export.columns]
+    csv = export[csv_cols].to_csv(index=False)
+    st.download_button(
+        label=translate_text(language_code, "doctrine_report.download_csv"),
+        data=csv,
+        file_name="low_stock_export.csv",
+        mime="text/csv",
+    )
 
 
 def main():
@@ -452,12 +522,8 @@ def main():
             key="low_stock_editor",
         )
 
-        # Selected items info
-        selected_rows = edited_df[edited_df["select"]]
-        if len(selected_rows) > 0:
-            st.info(
-                translate_text(language_code, "low_stock.selected_items", count=len(selected_rows))
-            )
+        # Export selected items (multibuy block + CSV)
+        _render_low_stock_export(edited_df, max_days_remaining, language_code)
 
         # Display chart
         st.subheader(translate_text(language_code, "low_stock.chart_section"))

--- a/tests/test_low_stock_export.py
+++ b/tests/test_low_stock_export.py
@@ -1,10 +1,12 @@
 """Tests for the Low Stock page export helpers."""
 
+import io
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
-from pages.low_stock import _render_low_stock_export, compute_restock_qty
+from pages.low_stock import EXPORT_CSV_COLUMNS, _render_low_stock_export, compute_restock_qty
 
 
 class TestComputeRestockQty:
@@ -29,6 +31,16 @@ class TestComputeRestockQty:
     def test_rounds_to_nearest_integer(self):
         # 3.4/day * 2 days = 6.8 -> rounds to 7.
         assert compute_restock_qty(avg_volume=3.4, max_days=2.0, current_stock=0.0) == 7
+
+    def test_nan_input_raises(self):
+        # Deliberately unhandled: the service sanitizes avg_volume and
+        # total_volume_remain with fillna(0.0) before they reach this function
+        # (services/low_stock_service.py). If that upstream invariant breaks,
+        # a loud ValueError beats silently exporting a garbage quantity.
+        with pytest.raises(ValueError):
+            compute_restock_qty(avg_volume=float("nan"), max_days=7.0, current_stock=0.0)
+        with pytest.raises(ValueError):
+            compute_restock_qty(avg_volume=10.0, max_days=7.0, current_stock=float("nan"))
 
 
 def _editor_frame():
@@ -68,16 +80,72 @@ class TestRenderLowStockExport:
         # Only the two ticked rows, name<TAB>restock_qty, unselected row absent.
         assert multibuy == "Tritanium\t500\nMexallon\t1"
 
+    def test_caption_states_target_days(self):
+        # A typo'd i18n key would render the raw key string and still "pass"
+        # every widget-call assertion, so pin the actual caption text — this
+        # also pins the f"{max_days:g}" formatting (7.0 -> "7").
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(_editor_frame(), max_days=7.0, language_code="en")
+
+        caption = mock_st.caption.call_args.args[0]
+        assert "7 days" in caption
+
     def test_csv_includes_restock_qty_and_joined_ships(self):
         with patch("pages.low_stock.st") as mock_st:
             _render_low_stock_export(_editor_frame(), max_days=7.0, language_code="en")
 
         csv_text = mock_st.download_button.call_args.kwargs["data"]
-        rows = pd.read_csv(pd.io.common.StringIO(csv_text))
+        rows = pd.read_csv(io.StringIO(csv_text))
+        # Pin the exact header so a rename in columns_to_show can't silently
+        # drop a column from the export (default mode: no fits_on_mkt).
+        assert list(rows.columns) == [
+            "type_id", "type_name", "restock_qty", "price", "days_remaining",
+            "total_volume_remain", "avg_volume", "category_name", "group_name", "ships",
+        ]
         assert list(rows["type_name"]) == ["Tritanium", "Mexallon"]
         assert list(rows["restock_qty"]) == [500, 1]
         # The ships list column is flattened to a single CSV-safe string.
         assert rows.loc[rows["type_name"] == "Mexallon", "ships"].iloc[0] == "Rifter (3); Punisher (1)"
+
+    def test_single_fit_frame_exports_fits_on_mkt(self):
+        # In single-fit mode the visible table gains fits_on_mkt; the CSV must
+        # include it (in table order) rather than silently dropping it.
+        frame = _editor_frame()
+        frame.insert(6, "fits_on_mkt", [4, 2, 9])
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(frame, max_days=7.0, language_code="en")
+
+        csv_text = mock_st.download_button.call_args.kwargs["data"]
+        rows = pd.read_csv(io.StringIO(csv_text))
+        assert list(rows.columns) == EXPORT_CSV_COLUMNS
+        assert list(rows["fits_on_mkt"]) == [4, 9]
+
+    def test_missing_required_column_logs_error_and_still_exports(self):
+        # A drift between columns_to_show and EXPORT_CSV_COLUMNS must fail
+        # loudly (logged) instead of silently shrinking the CSV schema.
+        frame = _editor_frame().drop(columns=["price"])
+        with patch("pages.low_stock.st") as mock_st, \
+                patch("pages.low_stock.logger") as mock_logger:
+            _render_low_stock_export(frame, max_days=7.0, language_code="en")
+
+        mock_logger.error.assert_called_once()
+        assert "price" in str(mock_logger.error.call_args)
+        csv_text = mock_st.download_button.call_args.kwargs["data"]
+        rows = pd.read_csv(io.StringIO(csv_text))
+        assert "price" not in rows.columns
+        assert list(rows["type_name"]) == ["Tritanium", "Mexallon"]
+
+    def test_none_ships_cells_export_as_empty(self):
+        # The page fills missing columns with None; a None ships cell must
+        # export as an empty CSV cell, not crash or leak "None" text.
+        frame = _editor_frame()
+        frame["ships"] = None
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(frame, max_days=7.0, language_code="en")
+
+        csv_text = mock_st.download_button.call_args.kwargs["data"]
+        rows = pd.read_csv(io.StringIO(csv_text))
+        assert rows["ships"].isna().all()
 
     def test_no_selection_shows_caption_and_skips_export(self):
         frame = _editor_frame()

--- a/tests/test_low_stock_export.py
+++ b/tests/test_low_stock_export.py
@@ -1,0 +1,90 @@
+"""Tests for the Low Stock page export helpers."""
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from pages.low_stock import _render_low_stock_export, compute_restock_qty
+
+
+class TestComputeRestockQty:
+    """compute_restock_qty = round(avg_volume * max_days - current_stock), floored at 1."""
+
+    def test_restocks_to_target_days(self):
+        # 10/day * 7 days = 70 target; 20 on market -> buy 50.
+        assert compute_restock_qty(avg_volume=10.0, max_days=7.0, current_stock=20.0) == 50
+
+    def test_already_stocked_floors_to_one(self):
+        # Target 70, but 200 already on market -> negative need, never below 1.
+        assert compute_restock_qty(avg_volume=10.0, max_days=7.0, current_stock=200.0) == 1
+
+    def test_zero_volume_floors_to_one(self):
+        # No recent sales: a ticked row still exports at least 1.
+        assert compute_restock_qty(avg_volume=0.0, max_days=7.0, current_stock=0.0) == 1
+
+    def test_zero_days_slider_floors_to_one(self):
+        # Degenerate slider=0 target yields negative need -> floored to 1.
+        assert compute_restock_qty(avg_volume=10.0, max_days=0.0, current_stock=5.0) == 1
+
+    def test_rounds_to_nearest_integer(self):
+        # 3.4/day * 2 days = 6.8 -> rounds to 7.
+        assert compute_restock_qty(avg_volume=3.4, max_days=2.0, current_stock=0.0) == 7
+
+
+def _editor_frame():
+    """A frame shaped like st.data_editor's return for the Low Stock table."""
+    return pd.DataFrame(
+        [
+            {  # selected: 100/day * 7 - 200 = 500
+                "select": True, "type_id": 34, "type_name": "Tritanium",
+                "price": 5.0, "days_remaining": 2.0, "total_volume_remain": 200.0,
+                "avg_volume": 100.0, "category_name": "Material",
+                "group_name": "Mineral", "ships": ["Rifter (3)"],
+            },
+            {  # not selected -> must be excluded from export
+                "select": False, "type_id": 35, "type_name": "Pyerite",
+                "price": 8.0, "days_remaining": 1.0, "total_volume_remain": 50.0,
+                "avg_volume": 100.0, "category_name": "Material",
+                "group_name": "Mineral", "ships": [],
+            },
+            {  # selected but over-stocked -> qty floors to 1
+                "select": True, "type_id": 36, "type_name": "Mexallon",
+                "price": 40.0, "days_remaining": 6.0, "total_volume_remain": 1000.0,
+                "avg_volume": 10.0, "category_name": "Material",
+                "group_name": "Mineral", "ships": ["Rifter (3)", "Punisher (1)"],
+            },
+        ]
+    )
+
+
+class TestRenderLowStockExport:
+    """The renderer builds an EVE-Multibuy block and CSV from the ticked rows."""
+
+    def test_multibuy_block_uses_restock_qty_for_selected_rows(self):
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(_editor_frame(), max_days=7.0, language_code="en")
+
+        multibuy = mock_st.code.call_args.args[0]
+        # Only the two ticked rows, name<TAB>restock_qty, unselected row absent.
+        assert multibuy == "Tritanium\t500\nMexallon\t1"
+
+    def test_csv_includes_restock_qty_and_joined_ships(self):
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(_editor_frame(), max_days=7.0, language_code="en")
+
+        csv_text = mock_st.download_button.call_args.kwargs["data"]
+        rows = pd.read_csv(pd.io.common.StringIO(csv_text))
+        assert list(rows["type_name"]) == ["Tritanium", "Mexallon"]
+        assert list(rows["restock_qty"]) == [500, 1]
+        # The ships list column is flattened to a single CSV-safe string.
+        assert rows.loc[rows["type_name"] == "Mexallon", "ships"].iloc[0] == "Rifter (3); Punisher (1)"
+
+    def test_no_selection_shows_caption_and_skips_export(self):
+        frame = _editor_frame()
+        frame["select"] = False
+        with patch("pages.low_stock.st") as mock_st:
+            _render_low_stock_export(frame, max_days=7.0, language_code="en")
+
+        mock_st.caption.assert_called_once()
+        mock_st.code.assert_not_called()
+        mock_st.download_button.assert_not_called()

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -184,6 +184,12 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.selected_items": (
             "{count} items selected. Visit the **Downloads** page for bulk CSV exports."
         ),
+        "low_stock.export_header": "Export selected items",
+        "low_stock.export_no_selection": "Select one or more rows to enable export.",
+        "low_stock.export_qty_caption": (
+            "Quantities restock each item to {days} days of stock "
+            "(avg daily volume × {days} − current stock)."
+        ),
         "low_stock.chart_section": "Days Remaining by Item",
         "low_stock.chart_title": "Days of Stock Remaining",
         "low_stock.chart_days_label": "Days Remaining",

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -181,9 +181,6 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.column_used_in_fits_help": "Doctrine ships that use this item.",
         "low_stock.column_category_help": "Category of the item.",
         "low_stock.column_group_help": "Group of the item.",
-        "low_stock.selected_items": (
-            "{count} items selected. Visit the **Downloads** page for bulk CSV exports."
-        ),
         "low_stock.export_header": "Export selected items",
         "low_stock.export_no_selection": "Select one or more rows to enable export.",
         "low_stock.export_qty_caption": (
@@ -920,7 +917,11 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.column_used_in_fits_help": "使用该物品的舰船配置。",
         "low_stock.column_category_help": "物品类别。",
         "low_stock.column_group_help": "物品分组。",
-        "low_stock.selected_items": "已选择 {count} 个物品。可前往 **Downloads** 页面批量导出 CSV。",
+        "low_stock.export_header": "导出所选物品",
+        "low_stock.export_no_selection": "选择一行或多行以启用导出。",
+        "low_stock.export_qty_caption": (
+            "数量将每件物品补货至 {days} 天的库存（日均成交量 × {days} − 当前库存）。"
+        ),
         "low_stock.chart_section": "按物品显示剩余天数",
         "low_stock.chart_title": "库存剩余天数",
         "low_stock.chart_days_label": "剩余天数",
@@ -1583,8 +1584,11 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.column_used_in_fits_help": "Doktrinschiffe, die diesen Artikel verwenden.",
         "low_stock.column_category_help": "Kategorie des Artikels.",
         "low_stock.column_group_help": "Gruppe des Artikels.",
-        "low_stock.selected_items": (
-            "{count} Artikel ausgewählt. Besuche die **Downloads**-Seite für CSV-Sammel-Exporte."
+        "low_stock.export_header": "Ausgewählte Artikel exportieren",
+        "low_stock.export_no_selection": "Wähle eine oder mehrere Zeilen aus, um den Export zu aktivieren.",
+        "low_stock.export_qty_caption": (
+            "Die Mengen füllen jeden Artikel auf {days} Tage Bestand auf "
+            "(durchschn. Tagesvolumen × {days} − aktueller Bestand)."
         ),
         "low_stock.chart_section": "Verbleibende Tage nach Artikel",
         "low_stock.chart_title": "Verbleibende Bestandstage",
@@ -2156,7 +2160,12 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.column_used_in_fits_help": "Vaisseaux de doctrine utilisant cet objet.",
         "low_stock.column_category_help": "Catégorie de l'objet.",
         "low_stock.column_group_help": "Groupe de l'objet.",
-        "low_stock.selected_items": "{count} objets sélectionnés. Consultez **Downloads** pour les exports CSV.",
+        "low_stock.export_header": "Exporter les objets sélectionnés",
+        "low_stock.export_no_selection": "Sélectionnez une ou plusieurs lignes pour activer l'export.",
+        "low_stock.export_qty_caption": (
+            "Les quantités réapprovisionnent chaque objet à {days} jours de stock "
+            "(volume quotidien moyen × {days} − stock actuel)."
+        ),
         "low_stock.chart_section": "Jours restants par objet",
         "low_stock.chart_title": "Jours de stock restants",
         "low_stock.chart_days_label": "Jours restants",
@@ -2725,7 +2734,12 @@ TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
         "low_stock.column_used_in_fits_help": "Доктринные корабли, использующие этот предмет.",
         "low_stock.column_category_help": "Категория предмета.",
         "low_stock.column_group_help": "Группа предмета.",
-        "low_stock.selected_items": "Выбрано предметов: {count}. Откройте **Downloads** для CSV экспортов.",
+        "low_stock.export_header": "Экспорт выбранных предметов",
+        "low_stock.export_no_selection": "Выберите одну или несколько строк, чтобы включить экспорт.",
+        "low_stock.export_qty_caption": (
+            "Количество пополняет запас каждого предмета до {days} дней "
+            "(средний дневной объём × {days} − текущий запас)."
+        ),
         "low_stock.chart_section": "Оставшиеся дни по предметам",
         "low_stock.chart_title": "Дни оставшегося запаса",
         "low_stock.chart_days_label": "Дни",


### PR DESCRIPTION
This PR adds the export functionality already in use on doctrine status and builder cost page to the low-stock page.